### PR TITLE
change specification of os_name and device_type

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git@github.com:adjust/dumbo.git
-  revision: 8e36cb477456f59f0c931185b08d593644d88bdf
+  revision: 0c5612179ec55afbe471b2079cc7a91077800b54
   specs:
     dumbo (0.0.4)
       activerecord

--- a/spec/binary_copy_spec.rb
+++ b/spec/binary_copy_spec.rb
@@ -20,7 +20,7 @@ describe 'binary_copy' do
      'os_name' => %w(android ios windows ios unknown),
      'istore' => ['"1"=>"1"', '"1"=>"2"', '"1"=>"3"', '"2"=>"1"', '"2"=>NULL', '"2"=>"2"'],
      'country_istore' => ['"de"=>"1"', '"es"=>"2"', '"de"=>"3"', '"us"=>"1"', '"zz"=>"2"', '"de"=>NULL'],
-     'device_istore' => ['"bot"=>"1"', '"phone"=>"2"', '"bot"=>"3"', '"resolver"=>"1"', '"server"=>"2"', '"server"=>NULL'],
+     'device_istore' => ['"bot"=>"1"', '"phone"=>"2"', '"bot"=>"3"', '"tablet"=>"1"', '"server"=>"2"', '"server"=>NULL'],
      'os_name_istore' => ['"android"=>"1"', '"windows"=>"2"', '"android"=>"3"', '"ios"=>"1"', '"unknown"=>"2"', '"ios"=>NULL']
    }
 

--- a/spec/device_type_pass_spec.rb
+++ b/spec/device_type_pass_spec.rb
@@ -7,7 +7,7 @@ describe 'device_type_pass' do
 
   let(:valid_device_types) do
     [
-      'bot', 'console', 'ipod', 'mac', 'pc', 'phone', 'resolver', 'server',
+      'bot', 'console', 'ipod', 'mac', 'pc', 'phone', 'server',
       'simulator', 'tablet', 'unknown'
     ]
   end

--- a/spec/functions_device_spec.rb
+++ b/spec/functions_device_spec.rb
@@ -14,66 +14,66 @@ describe 'functions_device' do
 
   it 'should fetch values' do
     query("SELECT fetchval('phone=>1'::device_istore, 'phone')").should match '1'
-    query("SELECT fetchval('resolver=>1'::device_istore, 'phone')").should match nil
+    query("SELECT fetchval('tablet=>1'::device_istore, 'phone')").should match nil
     query("SELECT fetchval('phone=>1, phone=>1'::device_istore, 'tablet')").should match nil
     query("SELECT fetchval('phone=>1, phone=>1'::device_istore, 'phone')").should match '2'
   end
 
   it 'should add to device_istores' do
-    query("SELECT add('phone=>1, resolver=>1'::device_istore, 'phone=>1, resolver=>1'::device_istore)").should match \
-      '"phone"=>"2", "resolver"=>"2"'
-    query("SELECT add('phone=>1, resolver=>1'::device_istore, 'bot=>1, resolver=>1'::device_istore)").should match \
-      '"bot"=>"1", "phone"=>"1", "resolver"=>"2"'
-    query("SELECT add('phone=>1, resolver=>1'::device_istore, 'bot=>-1, resolver=>1'::device_istore)").should match \
-      '"bot"=>"-1", "phone"=>"1", "resolver"=>"2"'
-    query("SELECT add('bot=>1, resolver=>1'::device_istore, 'bot=>-1, resolver=>1'::device_istore)").should match \
-      '"bot"=>"0", "resolver"=>"2"'
-    query("SELECT add('bot=>-1, resolver=>1'::device_istore, 'bot=>-1, resolver=>1'::device_istore)").should match \
-      '"bot"=>"-2", "resolver"=>"2"'
-    query("SELECT add('bot=>-1, resolver=>1'::device_istore, 1)").should match \
-      '"bot"=>"0", "resolver"=>"2"'
-    query("SELECT add('bot=>-1, resolver=>1'::device_istore, -1)").should match \
-      '"bot"=>"-2", "resolver"=>"0"'
-    query("SELECT add('bot=>-1, resolver=>1'::device_istore, 0)").should match \
-      '"bot"=>"-1", "resolver"=>"1"'
+    query("SELECT add('phone=>1, tablet=>1'::device_istore, 'phone=>1, tablet=>1'::device_istore)").should match \
+      '"phone"=>"2", "tablet"=>"2"'
+    query("SELECT add('phone=>1, tablet=>1'::device_istore, 'bot=>1, tablet=>1'::device_istore)").should match \
+      '"bot"=>"1", "phone"=>"1", "tablet"=>"2"'
+    query("SELECT add('phone=>1, tablet=>1'::device_istore, 'bot=>-1, tablet=>1'::device_istore)").should match \
+      '"bot"=>"-1", "phone"=>"1", "tablet"=>"2"'
+    query("SELECT add('bot=>1, tablet=>1'::device_istore, 'bot=>-1, tablet=>1'::device_istore)").should match \
+      '"bot"=>"0", "tablet"=>"2"'
+    query("SELECT add('bot=>-1, tablet=>1'::device_istore, 'bot=>-1, tablet=>1'::device_istore)").should match \
+      '"bot"=>"-2", "tablet"=>"2"'
+    query("SELECT add('bot=>-1, tablet=>1'::device_istore, 1)").should match \
+      '"bot"=>"0", "tablet"=>"2"'
+    query("SELECT add('bot=>-1, tablet=>1'::device_istore, -1)").should match \
+      '"bot"=>"-2", "tablet"=>"0"'
+    query("SELECT add('bot=>-1, tablet=>1'::device_istore, 0)").should match \
+      '"bot"=>"-1", "tablet"=>"1"'
   end
 
   it 'should substract device_istores' do
-    query("SELECT subtract('phone=>1, resolver=>1'::device_istore, 'phone=>1, resolver=>1'::device_istore)").should match \
-      '"phone"=>"0", "resolver"=>"0"'
-    query("SELECT subtract('phone=>1, resolver=>1'::device_istore, 'bot=>1, resolver=>1'::device_istore)").should match \
-      '"bot"=>"-1", "phone"=>"1", "resolver"=>"0"'
-    query("SELECT subtract('phone=>1, resolver=>1'::device_istore, 'bot=>-1, resolver=>1'::device_istore)").should match \
-      '"bot"=>"1", "phone"=>"1", "resolver"=>"0"'
-    query("SELECT subtract('bot=>1, resolver=>1'::device_istore, 'bot=>-1, resolver=>1'::device_istore)").should match \
-      '"bot"=>"2", "resolver"=>"0"'
-    query("SELECT subtract('bot=>-1, resolver=>1'::device_istore, 'bot=>-1, resolver=>1'::device_istore)").should match \
-      '"bot"=>"0", "resolver"=>"0"'
-    query("SELECT subtract('bot=>-1, resolver=>1'::device_istore, 1)").should match \
-      '"bot"=>"-2", "resolver"=>"0"'
-    query("SELECT subtract('bot=>-1, resolver=>1'::device_istore, -1)").should match \
-      '"bot"=>"0", "resolver"=>"2"'
-    query("SELECT subtract('bot=>-1, resolver=>1'::device_istore, 0)").should match \
-      '"bot"=>"-1", "resolver"=>"1"'
+    query("SELECT subtract('phone=>1, tablet=>1'::device_istore, 'phone=>1, tablet=>1'::device_istore)").should match \
+      '"phone"=>"0", "tablet"=>"0"'
+    query("SELECT subtract('phone=>1, tablet=>1'::device_istore, 'bot=>1, tablet=>1'::device_istore)").should match \
+      '"bot"=>"-1", "phone"=>"1", "tablet"=>"0"'
+    query("SELECT subtract('phone=>1, tablet=>1'::device_istore, 'bot=>-1, tablet=>1'::device_istore)").should match \
+      '"bot"=>"1", "phone"=>"1", "tablet"=>"0"'
+    query("SELECT subtract('bot=>1, tablet=>1'::device_istore, 'bot=>-1, tablet=>1'::device_istore)").should match \
+      '"bot"=>"2", "tablet"=>"0"'
+    query("SELECT subtract('bot=>-1, tablet=>1'::device_istore, 'bot=>-1, tablet=>1'::device_istore)").should match \
+      '"bot"=>"0", "tablet"=>"0"'
+    query("SELECT subtract('bot=>-1, tablet=>1'::device_istore, 1)").should match \
+      '"bot"=>"-2", "tablet"=>"0"'
+    query("SELECT subtract('bot=>-1, tablet=>1'::device_istore, -1)").should match \
+      '"bot"=>"0", "tablet"=>"2"'
+    query("SELECT subtract('bot=>-1, tablet=>1'::device_istore, 0)").should match \
+      '"bot"=>"-1", "tablet"=>"1"'
   end
 
   it 'should multiply device_istores' do
-    query("SELECT multiply('phone=>1, resolver=>1'::device_istore, 'phone=>1, resolver=>1'::device_istore)").should match \
-      '"phone"=>"1", "resolver"=>"1"'
-    query("SELECT multiply('phone=>1, resolver=>1'::device_istore, 'bot=>1, resolver=>1'::device_istore)").should match \
-      '"bot"=>NULL, "phone"=>NULL, "resolver"=>"1"'
-    query("SELECT multiply('phone=>1, resolver=>1'::device_istore, 'bot=>-1, resolver=>1'::device_istore)").should match \
-      '"bot"=>NULL, "phone"=>NULL, "resolver"=>"1"'
-    query("SELECT multiply('bot=>1, resolver=>1'::device_istore, 'bot=>-1, resolver=>1'::device_istore)").should match \
-      '"bot"=>"-1", "resolver"=>"1"'
-    query("SELECT multiply('bot=>-1, resolver=>1'::device_istore, 'bot=>-1, resolver=>1'::device_istore)").should match \
-      '"bot"=>"1", "resolver"=>"1"'
-    query("SELECT multiply('bot=>-1, resolver=>1'::device_istore, 1)").should match \
-      '"bot"=>"-1", "resolver"=>"1"'
-    query("SELECT multiply('bot=>-1, resolver=>1'::device_istore, -1)").should match \
-      '"bot"=>"1", "resolver"=>"-1"'
-    query("SELECT multiply('bot=>-1, resolver=>1'::device_istore, 0)").should match \
-      '"bot"=>"0", "resolver"=>"0"'
+    query("SELECT multiply('phone=>1, tablet=>1'::device_istore, 'phone=>1, tablet=>1'::device_istore)").should match \
+      '"phone"=>"1", "tablet"=>"1"'
+    query("SELECT multiply('phone=>1, tablet=>1'::device_istore, 'bot=>1, tablet=>1'::device_istore)").should match \
+      '"bot"=>NULL, "phone"=>NULL, "tablet"=>"1"'
+    query("SELECT multiply('phone=>1, tablet=>1'::device_istore, 'bot=>-1, tablet=>1'::device_istore)").should match \
+      '"bot"=>NULL, "phone"=>NULL, "tablet"=>"1"'
+    query("SELECT multiply('bot=>1, tablet=>1'::device_istore, 'bot=>-1, tablet=>1'::device_istore)").should match \
+      '"bot"=>"-1", "tablet"=>"1"'
+    query("SELECT multiply('bot=>-1, tablet=>1'::device_istore, 'bot=>-1, tablet=>1'::device_istore)").should match \
+      '"bot"=>"1", "tablet"=>"1"'
+    query("SELECT multiply('bot=>-1, tablet=>1'::device_istore, 1)").should match \
+      '"bot"=>"-1", "tablet"=>"1"'
+    query("SELECT multiply('bot=>-1, tablet=>1'::device_istore, -1)").should match \
+      '"bot"=>"1", "tablet"=>"-1"'
+    query("SELECT multiply('bot=>-1, tablet=>1'::device_istore, 0)").should match \
+      '"bot"=>"0", "tablet"=>"0"'
   end
 
   it 'should create an device_istore from array' do
@@ -82,35 +82,35 @@ describe 'functions_device' do
     query("SELECT device_istore_from_array(ARRAY['bot','bot','bot','bot'])").should match \
       '"bot"=>"4"'
     query("SELECT device_istore_from_array(NULL::text[])").should match nil
-    query("SELECT device_istore_from_array(ARRAY['bot','phone','resolver','mac'])").should match \
-      '"bot"=>"1", "mac"=>"1", "phone"=>"1", "resolver"=>"1"'
-    query("SELECT device_istore_from_array(ARRAY['bot','phone','resolver','mac','bot','phone','resolver','mac'])").should match \
-      '"bot"=>"2", "mac"=>"2", "phone"=>"2", "resolver"=>"2"'
-    query("SELECT device_istore_from_array(ARRAY['bot','phone','resolver','mac','bot','phone','resolver','mac',NULL])").should match \
-      '"bot"=>"2", "mac"=>"2", "phone"=>"2", "resolver"=>"2"'
-    query("SELECT device_istore_from_array(ARRAY[NULL,'bot','phone','resolver','mac','bot','phone','resolver','mac'])").should match \
-      '"bot"=>"2", "mac"=>"2", "phone"=>"2", "resolver"=>"2"'
-    query("SELECT device_istore_from_array(ARRAY[NULL,'bot','phone','resolver','mac','bot','phone','resolver','mac',NULL])").should match \
-      '"bot"=>"2", "mac"=>"2", "phone"=>"2", "resolver"=>"2"'
-    query("SELECT device_istore_from_array(ARRAY['bot','phone','resolver','mac','bot','phone','resolver','mac',NULL,'bot',NULL,'bot','phone','resolver','mac','bot','phone','resolver','mac'])").should match \
-      '"bot"=>"5", "mac"=>"4", "phone"=>"4", "resolver"=>"4"'
+    query("SELECT device_istore_from_array(ARRAY['bot','phone','tablet','mac'])").should match \
+      '"bot"=>"1", "mac"=>"1", "phone"=>"1", "tablet"=>"1"'
+    query("SELECT device_istore_from_array(ARRAY['bot','phone','tablet','mac','bot','phone','tablet','mac'])").should match \
+      '"bot"=>"2", "mac"=>"2", "phone"=>"2", "tablet"=>"2"'
+    query("SELECT device_istore_from_array(ARRAY['bot','phone','tablet','mac','bot','phone','tablet','mac',NULL])").should match \
+      '"bot"=>"2", "mac"=>"2", "phone"=>"2", "tablet"=>"2"'
+    query("SELECT device_istore_from_array(ARRAY[NULL,'bot','phone','tablet','mac','bot','phone','tablet','mac'])").should match \
+      '"bot"=>"2", "mac"=>"2", "phone"=>"2", "tablet"=>"2"'
+    query("SELECT device_istore_from_array(ARRAY[NULL,'bot','phone','tablet','mac','bot','phone','tablet','mac',NULL])").should match \
+      '"bot"=>"2", "mac"=>"2", "phone"=>"2", "tablet"=>"2"'
+    query("SELECT device_istore_from_array(ARRAY['bot','phone','tablet','mac','bot','phone','tablet','mac',NULL,'bot',NULL,'bot','phone','tablet','mac','bot','phone','tablet','mac'])").should match \
+      '"bot"=>"5", "mac"=>"4", "phone"=>"4", "tablet"=>"4"'
     query("SELECT device_istore_from_array(ARRAY['bot'::device_type])").should match \
       '"bot"=>"1"'
     query("SELECT device_istore_from_array(ARRAY['bot'::device_type,'bot'::device_type,'bot'::device_type,'bot'::device_type])").should match \
       '"bot"=>"4"'
     query("SELECT device_istore_from_array(NULL::text[])").should match nil
-    query("SELECT device_istore_from_array(ARRAY['bot'::device_type,'phone'::device_type,'resolver'::device_type,'mac'::device_type])").should match \
-      '"bot"=>"1", "mac"=>"1", "phone"=>"1", "resolver"=>"1"'
-    query("SELECT device_istore_from_array(ARRAY['bot'::device_type,'phone'::device_type,'resolver'::device_type,'mac'::device_type,'bot'::device_type,'phone'::device_type,'resolver'::device_type,'mac'::device_type])").should match \
-      '"bot"=>"2", "mac"=>"2", "phone"=>"2", "resolver"=>"2"'
-    query("SELECT device_istore_from_array(ARRAY['bot'::device_type,'phone'::device_type,'resolver'::device_type,'mac'::device_type,'bot'::device_type,'phone'::device_type,'resolver'::device_type,'mac'::device_type,NULL])").should match \
-      '"bot"=>"2", "mac"=>"2", "phone"=>"2", "resolver"=>"2"'
-    query("SELECT device_istore_from_array(ARRAY[NULL,'bot'::device_type,'phone'::device_type,'resolver'::device_type,'mac'::device_type,'bot'::device_type,'phone'::device_type,'resolver'::device_type,'mac'::device_type])").should match \
-      '"bot"=>"2", "mac"=>"2", "phone"=>"2", "resolver"=>"2"'
-    query("SELECT device_istore_from_array(ARRAY[NULL,'bot'::device_type,'phone'::device_type,'resolver'::device_type,'mac'::device_type,'bot'::device_type,'phone'::device_type,'resolver'::device_type,'mac'::device_type,NULL])").should match \
-      '"bot"=>"2", "mac"=>"2", "phone"=>"2", "resolver"=>"2"'
-    query("SELECT device_istore_from_array(ARRAY['bot'::device_type,'phone'::device_type,'resolver'::device_type,'mac'::device_type,'bot'::device_type,'phone'::device_type,'resolver'::device_type,'mac'::device_type,NULL,'bot'::device_type,NULL,'bot'::device_type,'phone'::device_type,'resolver'::device_type,'mac'::device_type,'bot'::device_type,'phone'::device_type,'resolver'::device_type,'mac'::device_type])").should match \
-      '"bot"=>"5", "mac"=>"4", "phone"=>"4", "resolver"=>"4"'
+    query("SELECT device_istore_from_array(ARRAY['bot'::device_type,'phone'::device_type,'tablet'::device_type,'mac'::device_type])").should match \
+      '"bot"=>"1", "mac"=>"1", "phone"=>"1", "tablet"=>"1"'
+    query("SELECT device_istore_from_array(ARRAY['bot'::device_type,'phone'::device_type,'tablet'::device_type,'mac'::device_type,'bot'::device_type,'phone'::device_type,'tablet'::device_type,'mac'::device_type])").should match \
+      '"bot"=>"2", "mac"=>"2", "phone"=>"2", "tablet"=>"2"'
+    query("SELECT device_istore_from_array(ARRAY['bot'::device_type,'phone'::device_type,'tablet'::device_type,'mac'::device_type,'bot'::device_type,'phone'::device_type,'tablet'::device_type,'mac'::device_type,NULL])").should match \
+      '"bot"=>"2", "mac"=>"2", "phone"=>"2", "tablet"=>"2"'
+    query("SELECT device_istore_from_array(ARRAY[NULL,'bot'::device_type,'phone'::device_type,'tablet'::device_type,'mac'::device_type,'bot'::device_type,'phone'::device_type,'tablet'::device_type,'mac'::device_type])").should match \
+      '"bot"=>"2", "mac"=>"2", "phone"=>"2", "tablet"=>"2"'
+    query("SELECT device_istore_from_array(ARRAY[NULL,'bot'::device_type,'phone'::device_type,'tablet'::device_type,'mac'::device_type,'bot'::device_type,'phone'::device_type,'tablet'::device_type,'mac'::device_type,NULL])").should match \
+      '"bot"=>"2", "mac"=>"2", "phone"=>"2", "tablet"=>"2"'
+    query("SELECT device_istore_from_array(ARRAY['bot'::device_type,'phone'::device_type,'tablet'::device_type,'mac'::device_type,'bot'::device_type,'phone'::device_type,'tablet'::device_type,'mac'::device_type,NULL,'bot'::device_type,NULL,'bot'::device_type,'phone'::device_type,'tablet'::device_type,'mac'::device_type,'bot'::device_type,'phone'::device_type,'tablet'::device_type,'mac'::device_type])").should match \
+      '"bot"=>"5", "mac"=>"4", "phone"=>"4", "tablet"=>"4"'
   end
 
   it 'should agg an array of device_istores' do
@@ -118,35 +118,35 @@ describe 'functions_device' do
       '"phone"=>"1"'
     query("SELECT device_istore_agg(ARRAY['phone=>1','phone=>1']::device_istore[])").should match \
       '"phone"=>"2"'
-    query("SELECT device_istore_agg(ARRAY['phone=>1,resolver=>1','phone=>1,resolver=>-1']::device_istore[])").should match \
-      '"phone"=>"2", "resolver"=>"0"'
-    query("SELECT device_istore_agg(ARRAY['phone=>1,resolver=>1','phone=>1,resolver=>-1',NULL]::device_istore[])").should match \
-      '"phone"=>"2", "resolver"=>"0"'
-    query("SELECT device_istore_agg(ARRAY[NULL,'phone=>1,resolver=>1','phone=>1,resolver=>-1']::device_istore[])").should match \
-      '"phone"=>"2", "resolver"=>"0"'
-    query("SELECT device_istore_agg(ARRAY[NULL,'phone=>1,resolver=>1','phone=>1,resolver=>-1',NULL]::device_istore[])").should match \
-      '"phone"=>"2", "resolver"=>"0"'
+    query("SELECT device_istore_agg(ARRAY['phone=>1,tablet=>1','phone=>1,tablet=>-1']::device_istore[])").should match \
+      '"phone"=>"2", "tablet"=>"0"'
+    query("SELECT device_istore_agg(ARRAY['phone=>1,tablet=>1','phone=>1,tablet=>-1',NULL]::device_istore[])").should match \
+      '"phone"=>"2", "tablet"=>"0"'
+    query("SELECT device_istore_agg(ARRAY[NULL,'phone=>1,tablet=>1','phone=>1,tablet=>-1']::device_istore[])").should match \
+      '"phone"=>"2", "tablet"=>"0"'
+    query("SELECT device_istore_agg(ARRAY[NULL,'phone=>1,tablet=>1','phone=>1,tablet=>-1',NULL]::device_istore[])").should match \
+      '"phone"=>"2", "tablet"=>"0"'
   end
 
   it 'should sum up device_istores' do
     query("SELECT device_istore_sum_up('phone=>1'::device_istore)").should match '1'
     query("SELECT device_istore_sum_up(NULL::device_istore)").should match nil
-    query("SELECT device_istore_sum_up('phone=>1, resolver=>1'::device_istore)").should match '2'
-    query("SELECT device_istore_sum_up('phone=>1 ,resolver=>-1, phone=>1'::device_istore)").should match '1'
+    query("SELECT device_istore_sum_up('phone=>1, tablet=>1'::device_istore)").should match '2'
+    query("SELECT device_istore_sum_up('phone=>1 ,tablet=>-1, phone=>1'::device_istore)").should match '1'
   end
 
   it 'should SUM device_istores FROM table' do
     query("CREATE TABLE test (a device_istore)")
-    query("INSERT INTO test VALUES ('phone=>1'), ('resolver=>1'), ('mac=>1')")
+    query("INSERT INTO test VALUES ('phone=>1'), ('tablet=>1'), ('mac=>1')")
     query("SELECT SUM(a) FROM test").should match \
-      '"mac"=>"1", "phone"=>"1", "resolver"=>"1"'
+      '"mac"=>"1", "phone"=>"1", "tablet"=>"1"'
   end
 
   it 'should SUM device_istores FROM table' do
     query("CREATE TABLE test (a device_istore)")
-    query("INSERT INTO test VALUES ('phone=>1'), ('resolver=>1'), ('mac=>1'), (NULL), ('mac=>3')")
+    query("INSERT INTO test VALUES ('phone=>1'), ('tablet=>1'), ('mac=>1'), (NULL), ('mac=>3')")
     query("SELECT SUM(a) FROM test").should match \
-      '"mac"=>"4", "phone"=>"1", "resolver"=>"1"'
+      '"mac"=>"4", "phone"=>"1", "tablet"=>"1"'
   end
 
 end

--- a/spec/os_name_test_spec.rb
+++ b/spec/os_name_test_spec.rb
@@ -6,7 +6,19 @@ describe 'os_name' do
   end
 
   it 'should pass valid os_name' do
-    %w(android ios windows windows unknown).each do |name|
+    [
+      'android',
+      'blackberry',
+      'ios',
+      'linux',
+      'macos',
+      'server',
+      'symbian',
+      'webos',
+      'windows',
+      'windows-phone',
+      'unknown'
+    ].each do |name|
       query("SELECT '#{name}'::os_name").should match name
     end
   end

--- a/src/device_type.c
+++ b/src/device_type.c
@@ -141,17 +141,16 @@ get_device_type_string(uint8 num)
 {
     switch (num)
     {
-        case 1:  return create_string(CONST_STRING("bot"));
-        case 2:  return create_string(CONST_STRING("console"));
-        case 3:  return create_string(CONST_STRING("ipod"));
-        case 4:  return create_string(CONST_STRING("mac"));
-        case 5:  return create_string(CONST_STRING("pc"));
-        case 6:  return create_string(CONST_STRING("phone"));
-        case 7:  return create_string(CONST_STRING("resolver"));
-        case 8:  return create_string(CONST_STRING("server"));
-        case 9:  return create_string(CONST_STRING("simulator"));
-        case 10: return create_string(CONST_STRING("tablet"));
-        case 11: return create_string(CONST_STRING("unknown"));
+        case  20:  return create_string(CONST_STRING("bot"));
+        case  40:  return create_string(CONST_STRING("console"));
+        case  80:  return create_string(CONST_STRING("ipod"));
+        case 100:  return create_string(CONST_STRING("mac"));
+        case 120:  return create_string(CONST_STRING("pc"));
+        case 140:  return create_string(CONST_STRING("phone"));
+        case 160:  return create_string(CONST_STRING("server"));
+        case 180:  return create_string(CONST_STRING("simulator"));
+        case 200: return create_string(CONST_STRING("tablet"));
+        case 255: return create_string(CONST_STRING("unknown"));
         default: elog(ERROR, "unknown device_type num");
     }
 }
@@ -161,17 +160,16 @@ get_device_type_length(uint8 num)
 {
     switch (num)
     {
-        case 1:  return (CONST_STRING_LENGTH("bot"));
-        case 2:  return (CONST_STRING_LENGTH("console"));
-        case 3:  return (CONST_STRING_LENGTH("ipod"));
-        case 4:  return (CONST_STRING_LENGTH("mac"));
-        case 5:  return (CONST_STRING_LENGTH("pc"));
-        case 6:  return (CONST_STRING_LENGTH("phone"));
-        case 7:  return (CONST_STRING_LENGTH("resolver"));
-        case 8:  return (CONST_STRING_LENGTH("server"));
-        case 9:  return (CONST_STRING_LENGTH("simulator"));
-        case 10: return (CONST_STRING_LENGTH("tablet"));
-        case 11: return (CONST_STRING_LENGTH("unknown"));
+        case  20:  return (CONST_STRING_LENGTH("bot"));
+        case  40:  return (CONST_STRING_LENGTH("console"));
+        case  80:  return (CONST_STRING_LENGTH("ipod"));
+        case 100:  return (CONST_STRING_LENGTH("mac"));
+        case 120:  return (CONST_STRING_LENGTH("pc"));
+        case 140:  return (CONST_STRING_LENGTH("phone"));
+        case 160:  return (CONST_STRING_LENGTH("server"));
+        case 180:  return (CONST_STRING_LENGTH("simulator"));
+        case 200: return (CONST_STRING_LENGTH("tablet"));
+        case 255: return (CONST_STRING_LENGTH("unknown"));
         default: elog(ERROR, "unknown device_type num");
     }
 }
@@ -195,15 +193,14 @@ get_device_type_num(char *str)
 {
     switch (str[0])
     {
-        case 'b': return check_device_type_num(str, 1);
-        case 'c': return check_device_type_num(str, 2);
-        case 'i': return check_device_type_num(str, 3);
-        case 'm': return check_device_type_num(str, 4);
+        case 'b': return check_device_type_num(str, 20);
+        case 'c': return check_device_type_num(str, 40);
+        case 'i': return check_device_type_num(str, 80);
+        case 'm': return check_device_type_num(str, 100);
         case 'p': return get_device_type_num_p(str);
-        case 'r': return check_device_type_num(str, 7);
         case 's': return get_device_type_num_s(str);
-        case 't': return check_device_type_num(str, 10);
-        case 'u': return check_device_type_num(str, 11);
+        case 't': return check_device_type_num(str, 200);
+        case 'u': return check_device_type_num(str, 255);
         default : return 0;
     }
 }
@@ -212,8 +209,8 @@ uint8
 get_device_type_num_p(char *str)
 {
     switch (str[1]) {
-        case 'c': return check_device_type_num(str, 5);
-        case 'h': return check_device_type_num(str, 6);
+        case 'c': return check_device_type_num(str, 120);
+        case 'h': return check_device_type_num(str, 140);
         default : return 0;
     }
 }
@@ -222,8 +219,8 @@ uint8
 get_device_type_num_s(char *str)
 {
     switch (str[1]) {
-        case 'e': return check_device_type_num(str, 8);
-        case 'i': return check_device_type_num(str, 9);
+        case 'e': return check_device_type_num(str, 160);
+        case 'i': return check_device_type_num(str, 180);
         default : return 0;
     }
 }

--- a/src/os_name.c
+++ b/src/os_name.c
@@ -15,7 +15,7 @@ os_name_in(PG_FUNCTION_ARGS)
     result = get_os_name_num(str);
     if (result == 0)
         elog(ERROR, "unknown input os_name");
-    PG_RETURN_POINTER(result);
+    PG_RETURN_OS_NAME(result);
 }
 
 PG_FUNCTION_INFO_V1(os_name_out);
@@ -125,12 +125,19 @@ get_os_name_string(uint8 num)
 {
     switch (num)
     {
-        case 1:  return create_string(CONST_STRING("android"));
-        case 2:  return create_string(CONST_STRING("ios"));
-        case 3:  return create_string(CONST_STRING("windows"));
-        case 4:  return create_string(CONST_STRING("windows-phone"));
-        case 5:  return create_string(CONST_STRING("unknown"));
-        default: return NULL;
+        case  20: return create_string(CONST_STRING("android"));
+        case  40: return create_string(CONST_STRING("bada"));
+        case  60: return create_string(CONST_STRING("blackberry"));
+        case  80: return create_string(CONST_STRING("ios"));
+        case 100: return create_string(CONST_STRING("linux"));
+        case 120: return create_string(CONST_STRING("macos"));
+        case 140: return create_string(CONST_STRING("server"));
+        case 160: return create_string(CONST_STRING("symbian"));
+        case 180: return create_string(CONST_STRING("webos"));
+        case 200: return create_string(CONST_STRING("windows"));
+        case 220: return create_string(CONST_STRING("windows-phone"));
+        case 255: return create_string(CONST_STRING("unknown"));
+        default: elog(ERROR, "internal error unexpected num in get_os_name_string");
     }
 }
 
@@ -139,11 +146,18 @@ get_os_name_length(uint8 num)
 {
     switch (num)
     {
-        case 1:  return (CONST_STRING_LENGTH("android"));
-        case 2:  return (CONST_STRING_LENGTH("ios"));
-        case 3:  return (CONST_STRING_LENGTH("windows"));
-        case 4:  return (CONST_STRING_LENGTH("windows-phone"));
-        case 5:  return (CONST_STRING_LENGTH("unknown"));
+        case  20: return (CONST_STRING_LENGTH("android"));
+        case  40: return (CONST_STRING_LENGTH("bada"));
+        case  60: return (CONST_STRING_LENGTH("blackberry"));
+        case  80: return (CONST_STRING_LENGTH("ios"));
+        case 100: return (CONST_STRING_LENGTH("linux"));
+        case 120: return (CONST_STRING_LENGTH("macos"));
+        case 140: return (CONST_STRING_LENGTH("server"));
+        case 160: return (CONST_STRING_LENGTH("symbian"));
+        case 180: return (CONST_STRING_LENGTH("webos"));
+        case 200: return (CONST_STRING_LENGTH("windows"));
+        case 220: return (CONST_STRING_LENGTH("windows-phone"));
+        case 255: return (CONST_STRING_LENGTH("unknown"));
         default: elog(ERROR, "unknown os_name type");
     }
 }
@@ -166,14 +180,48 @@ get_os_name_num(char *str)
 {
     switch (str[0])
     {
-        case 'a': return check_os_name_num(str, 1);
-        case 'i': return check_os_name_num(str, 2);
-        case 'w':
-                  if (str[7] == '-')
-                      return check_os_name_num(str, 4);
-                  else
-                      return check_os_name_num(str, 3);
-        case 'u': return check_os_name_num(str, 5);
+        case 'a': return check_os_name_num(str, 20);
+        case 'b': return get_os_name_num_b(str);
+        case 'i': return check_os_name_num(str, 80);
+        case 'l': return check_os_name_num(str, 100);
+        case 'm': return check_os_name_num(str, 120);
+        case 's': return get_os_name_num_s(str);
+        case 'w': return get_os_name_num_w(str);
+        case 'u': return check_os_name_num(str, 255);
+        default : return 0;
+    }
+}
+
+uint8
+get_os_name_num_b(char *str)
+{
+    switch (str[1]) {
+        case 'a': return check_os_name_num(str, 40);
+        case 'l': return check_os_name_num(str, 60);
+        default : return 0;
+    }
+}
+
+uint8
+get_os_name_num_s(char *str)
+{
+    switch (str[1]) {
+        case 'e': return check_os_name_num(str, 140);
+        case 'y': return check_os_name_num(str, 160);
+        default : return 0;
+    }
+}
+
+uint8
+get_os_name_num_w(char *str)
+{
+    switch (str[1]) {
+        case 'e': return check_os_name_num(str, 180);
+        case 'i':
+            if(str[7] == '-'  )
+                return check_os_name_num(str, 220);
+            else
+                return check_os_name_num(str, 200);
         default : return 0;
     }
 }

--- a/src/os_name.h
+++ b/src/os_name.h
@@ -23,6 +23,10 @@ Datum os_name_gt(PG_FUNCTION_ARGS);
 Datum os_name_cmp(PG_FUNCTION_ARGS);
 
 uint8 get_os_name_num(char *str);
+uint8 get_os_name_num_b(char *str);
+uint8 get_os_name_num_s(char *str);
+uint8 get_os_name_num_w(char *str);
+
 
 char * get_os_name_string (uint8 num);
 int get_os_name_length (uint8 num);


### PR DESCRIPTION
as per discussion with @wellle and @elmacnifico we need additional os_names
and don't need the resolver device_type anymore
I also put some space between each definition to have the chance to add thinks without destroying current order
