### PR TITLE
optimize SUM Aggregate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+sudo: required
+dist: trusty
+language: c
+services:
+  - postgresql
+addons:
+  postgresql: "9.6"
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y postgresql-server-dev-9.6
+before_script:
+  - sudo chmod 777 /usr/lib/postgresql/9.6/lib /usr/share/postgresql/9.6/extension
+script:
+  - ./travis.sh

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # Gemfile
 source 'https://rubygems.org'
-# gem 'dumbo', :git => "git@github.com:adjust/dumbo.git"
-gem 'dumbo' #, :path => "/Users/manuel/adjust/dumbo"
+gem 'dumbo', git: 'git@github.com:adjust/dumbo.git', branch: 'version-1.0.0'
+# gem 'dumbo' #, :path => "/Users/manuel/adjust/dumbo"
 gem 'pg'
 gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,68 +1,34 @@
+GIT
+  remote: git@github.com:adjust/dumbo.git
+  revision: ef139ceb1874bb5869902f8280dda2ef7a64c86d
+  branch: version-1.0.0
+  specs:
+    dumbo (1.0.0)
+      erubis (~> 2.7)
+      pg (~> 0.19)
+      thor (~> 0.19)
+
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (4.2.5)
-      activesupport (= 4.2.5)
-      builder (~> 3.1)
-    activerecord (4.2.5)
-      activemodel (= 4.2.5)
-      activesupport (= 4.2.5)
-      arel (~> 6.0)
-    activesupport (4.2.5)
-      i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
-      minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
-      tzinfo (~> 1.1)
-    arel (6.0.3)
-    builder (3.2.2)
-    coderay (1.1.0)
-    diff-lcs (1.2.5)
-    dumbo (0.0.4)
-      activerecord
-      activesupport
-      bundler (~> 1.5)
-      erubis
-      pg (> 0.17)
-      rake
-      rspec (~> 3.0.0)
-      thor
+    coderay (1.1.1)
     erubis (2.7.0)
-    i18n (0.7.0)
-    json (1.8.3)
     method_source (0.8.2)
-    minitest (5.8.3)
-    pg (0.18.4)
-    pry (0.10.3)
+    pg (0.20.0)
+    pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    rake (10.4.2)
-    rspec (3.0.0)
-      rspec-core (~> 3.0.0)
-      rspec-expectations (~> 3.0.0)
-      rspec-mocks (~> 3.0.0)
-    rspec-core (3.0.4)
-      rspec-support (~> 3.0.0)
-    rspec-expectations (3.0.4)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.0.0)
-    rspec-mocks (3.0.4)
-      rspec-support (~> 3.0.0)
-    rspec-support (3.0.4)
     slop (3.6.0)
-    thor (0.19.1)
-    thread_safe (0.3.5)
-    tzinfo (1.2.2)
-      thread_safe (~> 0.1)
+    thor (0.19.4)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  dumbo
+  dumbo!
   pg
   pry
 
 BUNDLED WITH
-   1.11.2
+   1.14.6

--- a/Makefile
+++ b/Makefile
@@ -8,5 +8,6 @@ OBJS = $(patsubst %.c,%.o,$(wildcard src/*.c))
 TESTS        = $(wildcard test/sql/*.sql)
 REGRESS      = $(patsubst test/sql/%.sql,%,$(TESTS))
 REGRESS_OPTS = --inputdir=test --load-language=plpgsql
+PG_CPPFLAGS  = --std=c99
 include $(PGXS)
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/adjust/istore.svg)](https://travis-ci.org/adjust/istore)
+
 # istore
 
 The idea of istore is to have an integer based hstore (thus the name) which

--- a/config/database.yml
+++ b/config/database.yml
@@ -15,17 +15,14 @@
 # min_messages: warning
 
 postgres: &postgres
-  adapter: postgresql
-  encoding: utf8
-  pool: 5
-  username: postgres
-  password:
+  client_encoding: utf8
+  user: postgres
   host: localhost
 
 development:
   <<: *postgres
-  database: istore_development
+  dbname: istore_development
 
 test:
   <<: *postgres
-  database: istore_test
+  dbname: istore_test

--- a/istore--0.1.2--0.1.3.sql
+++ b/istore--0.1.2--0.1.3.sql
@@ -1,0 +1,103 @@
+----
+CREATE OR REPLACE FUNCTION bigistore_agg_finalfn(internal)
+ RETURNS bigistore
+ LANGUAGE c
+ IMMUTABLE STRICT
+AS 'istore', $function$bigistore_agg_finalfn_pairs$function$;
+----
+CREATE OR REPLACE FUNCTION istore_max_transfn(internal, bigistore)
+ RETURNS internal
+ LANGUAGE c
+ IMMUTABLE
+AS 'istore', $function$bigistore_max_transfn$function$;
+----
+CREATE OR REPLACE FUNCTION istore_min_transfn(internal, bigistore)
+ RETURNS internal
+ LANGUAGE c
+ IMMUTABLE
+AS 'istore', $function$bigistore_min_transfn$function$;
+----
+CREATE OR REPLACE FUNCTION istore_sum_transfn(internal, bigistore)
+ RETURNS internal
+ LANGUAGE c
+ IMMUTABLE
+AS 'istore', $function$bigistore_sum_transfn$function$;
+----
+CREATE OR REPLACE FUNCTION istore_agg_finalfn_pairs(internal)
+ RETURNS istore
+ LANGUAGE c
+ IMMUTABLE STRICT
+AS 'istore', $function$istore_agg_finalfn_pairs$function$;
+----
+CREATE OR REPLACE FUNCTION istore_max_transfn(internal, istore)
+ RETURNS internal
+ LANGUAGE c
+ IMMUTABLE
+AS 'istore', $function$istore_max_transfn$function$;
+----
+CREATE OR REPLACE FUNCTION istore_min_transfn(internal, istore)
+ RETURNS internal
+ LANGUAGE c
+ IMMUTABLE
+AS 'istore', $function$istore_min_transfn$function$;
+----
+CREATE OR REPLACE FUNCTION istore_sum_transfn(internal, istore)
+ RETURNS internal
+ LANGUAGE c
+ IMMUTABLE
+AS 'istore', $function$istore_sum_transfn$function$;
+----aggregates----
+  DROP AGGREGATE IF EXISTS max (bigistore);
+    CREATE AGGREGATE max(bigistore) (
+    SFUNC = public.istore_max_transfn,
+  STYPE = internal,
+  FINALFUNC = bigistore_agg_finalfn
+  );
+
+
+----
+  DROP AGGREGATE IF EXISTS min (bigistore);
+    CREATE AGGREGATE min(bigistore) (
+    SFUNC = public.istore_min_transfn,
+  STYPE = internal,
+  FINALFUNC = bigistore_agg_finalfn
+  );
+
+
+----
+  DROP AGGREGATE IF EXISTS sum (bigistore);
+    CREATE AGGREGATE sum(bigistore) (
+    SFUNC = public.istore_sum_transfn,
+  STYPE = internal,
+  FINALFUNC = bigistore_agg_finalfn
+  );
+
+
+----
+  DROP AGGREGATE IF EXISTS max (istore);
+    CREATE AGGREGATE max(istore) (
+    SFUNC = public.istore_max_transfn,
+  STYPE = internal,
+  FINALFUNC = istore_agg_finalfn_pairs
+  );
+
+
+----
+  DROP AGGREGATE IF EXISTS min (istore);
+    CREATE AGGREGATE min(istore) (
+    SFUNC = public.istore_min_transfn,
+  STYPE = internal,
+  FINALFUNC = istore_agg_finalfn_pairs
+  );
+
+
+----
+  DROP AGGREGATE IF EXISTS sum (istore);
+    CREATE AGGREGATE sum(istore) (
+    SFUNC = public.istore_sum_transfn,
+  STYPE = internal,
+  FINALFUNC = bigistore_agg_finalfn
+  );
+
+----functions----
+DROP FUNCTION IF EXISTS istore_agg_finalfn(internal);

--- a/istore--0.1.3--0.1.2.sql
+++ b/istore--0.1.3--0.1.2.sql
@@ -1,0 +1,74 @@
+----functions----
+CREATE OR REPLACE FUNCTION istore_agg_finalfn(internal)
+ RETURNS bigistore
+ LANGUAGE c
+ IMMUTABLE STRICT
+AS 'istore', $function$istore_agg_finalfn$function$;
+----
+CREATE OR REPLACE FUNCTION bigistore_agg_finalfn(internal)
+ RETURNS bigistore
+ LANGUAGE c
+ IMMUTABLE STRICT
+AS 'istore', $function$bigistore_agg_finalfn$function$;
+
+----aggregates----
+  DROP AGGREGATE IF EXISTS max (bigistore);
+    CREATE AGGREGATE max(bigistore) (
+    SFUNC = public.istore_val_larger,
+  STYPE = bigistore
+  );
+
+
+----
+  DROP AGGREGATE IF EXISTS min (bigistore);
+    CREATE AGGREGATE min(bigistore) (
+    SFUNC = public.istore_val_smaller,
+  STYPE = bigistore
+  );
+
+----
+  DROP AGGREGATE IF EXISTS sum (bigistore);
+    CREATE AGGREGATE sum(bigistore) (
+    SFUNC = array_agg_transfn,
+  STYPE = internal,
+  FINALFUNC = bigistore_agg_finalfn
+  );
+
+----
+  DROP AGGREGATE IF EXISTS max (istore);
+    CREATE AGGREGATE max(istore) (
+    SFUNC = public.istore_val_larger,
+  STYPE = istore
+  );
+
+
+----
+  DROP AGGREGATE IF EXISTS min (istore);
+    CREATE AGGREGATE min(istore) (
+    SFUNC = public.istore_val_smaller,
+  STYPE = istore
+  );
+
+
+----
+  DROP AGGREGATE IF EXISTS sum (istore);
+    CREATE AGGREGATE sum(istore) (
+    SFUNC = array_agg_transfn,
+  STYPE = internal,
+  FINALFUNC = istore_agg_finalfn
+  );
+
+----
+DROP FUNCTION IF EXISTS istore_max_transfn(internal, bigistore);
+----
+DROP FUNCTION IF EXISTS istore_min_transfn(internal, bigistore);
+----
+DROP FUNCTION IF EXISTS istore_sum_transfn(internal, bigistore);
+----
+DROP FUNCTION IF EXISTS istore_agg_finalfn_pairs(internal);
+----
+DROP FUNCTION IF EXISTS istore_max_transfn(internal, istore);
+----
+DROP FUNCTION IF EXISTS istore_min_transfn(internal, istore);
+----
+DROP FUNCTION IF EXISTS istore_sum_transfn(internal, istore);

--- a/istore--0.1.3.sql
+++ b/istore--0.1.3.sql
@@ -1,0 +1,608 @@
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION istore" to load this file. \quit
+--source file sql/types.sql
+CREATE FUNCTION istore_in(cstring)
+    RETURNS istore
+    AS 'istore'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION istore_out(istore)
+    RETURNS cstring
+    AS 'istore'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION istore_send(istore)
+    RETURNS bytea
+    AS 'istore'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION istore_recv(internal)
+    RETURNS istore
+    AS 'istore'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE TYPE istore (
+    INPUT   = istore_in,
+    OUTPUT  = istore_out,
+    RECEIVE = istore_recv,
+    SEND    = istore_send,
+    STORAGE = EXTENDED
+);
+
+CREATE FUNCTION bigistore_in(cstring)
+    RETURNS bigistore
+    AS 'istore'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION bigistore_out(bigistore)
+    RETURNS cstring
+    AS 'istore'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION bigistore_send(bigistore)
+    RETURNS bytea
+    AS 'istore'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION bigistore_recv(internal)
+    RETURNS bigistore
+    AS 'istore'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE TYPE bigistore (
+    INPUT   = bigistore_in,
+    OUTPUT  = bigistore_out,
+    RECEIVE = bigistore_recv,
+    SEND    = bigistore_send,
+    STORAGE = EXTENDED
+);
+ 
+--source file sql/istore.sql
+--require types
+
+CREATE FUNCTION exist(istore, integer)
+    RETURNS boolean
+    AS 'istore', 'istore_exist'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION fetchval(istore, integer)
+    RETURNS integer
+    AS 'istore', 'istore_fetchval'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION each(IN is istore,
+    OUT key integer,
+    OUT value integer)
+RETURNS SETOF record
+AS 'istore','istore_each'
+LANGUAGE C STRICT IMMUTABLE;
+
+CREATE FUNCTION compact(istore)
+    RETURNS istore
+    AS 'istore', 'istore_compact'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION add(istore, istore)
+    RETURNS istore
+    AS 'istore', 'istore_add'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION add(istore, integer)
+    RETURNS istore
+    AS 'istore', 'istore_add_integer'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION subtract(istore, istore)
+    RETURNS istore
+    AS 'istore', 'istore_subtract'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION subtract(istore, integer)
+    RETURNS istore
+    AS 'istore', 'istore_subtract_integer'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION multiply(istore, istore)
+    RETURNS istore
+    AS 'istore', 'istore_multiply'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION multiply(istore, integer)
+    RETURNS istore
+    AS 'istore', 'istore_multiply_integer'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION divide(istore, istore)
+    RETURNS istore
+    AS 'istore', 'istore_divide'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION divide(istore, integer)
+    RETURNS istore
+    AS 'istore', 'istore_divide_integer'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION istore(integer[])
+    RETURNS istore
+    AS 'istore', 'istore_from_intarray'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION sum_up(istore)
+    RETURNS bigint
+    AS 'istore', 'istore_sum_up'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION sum_up(istore, integer)
+    RETURNS bigint
+    AS 'istore', 'istore_sum_up'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION istore(integer[], integer[])
+    RETURNS istore
+    AS 'istore', 'istore_array_add'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION fill_gaps(istore, integer, integer DEFAULT 0)
+    RETURNS istore
+    AS 'istore', 'istore_fill_gaps'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION accumulate(istore)
+    RETURNS istore
+    AS 'istore', 'istore_accumulate'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION accumulate(istore, integer)
+    RETURNS istore
+    AS 'istore', 'istore_accumulate'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION istore_seed(integer, integer, integer)
+    RETURNS istore
+    AS 'istore'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION istore_val_larger(istore, istore)
+    RETURNS istore
+    AS 'istore'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION istore_val_smaller(istore, istore)
+    RETURNS istore
+    AS 'istore'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION akeys(istore)
+    RETURNS integer[]
+    AS 'istore' ,'istore_akeys'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION avals(istore)
+    RETURNS integer[]
+    AS 'istore' ,'istore_avals'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION skeys(istore)
+    RETURNS setof int
+    AS 'istore' ,'istore_skeys'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION svals(istore)
+    RETURNS setof int
+    AS 'istore' ,'istore_svals'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION istore_sum_transfn(internal, istore)
+    RETURNS internal
+    AS 'istore' ,'istore_sum_transfn'
+    LANGUAGE C IMMUTABLE;
+
+CREATE FUNCTION istore_min_transfn(internal, istore)
+    RETURNS internal
+    AS 'istore'
+    LANGUAGE C IMMUTABLE;
+
+CREATE FUNCTION istore_max_transfn(internal, istore)
+    RETURNS internal
+    AS 'istore'
+    LANGUAGE C IMMUTABLE;
+
+CREATE FUNCTION istore_agg_finalfn_pairs(internal)
+    RETURNS istore
+    AS 'istore' ,'istore_agg_finalfn_pairs'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION istore_to_json(istore)
+RETURNS json
+AS 'istore', 'istore_to_json'
+LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION bigistore_agg_finalfn(internal)
+    RETURNS bigistore
+    AS 'istore' ,'bigistore_agg_finalfn_pairs'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE AGGREGATE SUM (
+    sfunc = istore_sum_transfn,
+    basetype = istore,
+    stype = internal,
+    finalfunc = bigistore_agg_finalfn
+);
+
+CREATE AGGREGATE MIN (
+    sfunc = istore_min_transfn,
+    basetype = istore,
+    stype = internal,
+    finalfunc = istore_agg_finalfn_pairs
+);
+
+CREATE AGGREGATE MAX (
+    sfunc = istore_max_transfn,
+    basetype = istore,
+    stype = internal,
+    finalfunc = istore_agg_finalfn_pairs
+);
+
+CREATE OPERATOR -> (
+    leftarg   = istore,
+    rightarg  = integer,
+    procedure = fetchval
+);
+
+CREATE OPERATOR ? (
+    leftarg   = istore,
+    rightarg  = integer,
+    procedure = exist
+);
+
+CREATE OPERATOR + (
+    leftarg   = istore,
+    rightarg  = istore,
+    procedure = add
+);
+
+CREATE OPERATOR + (
+    leftarg   = istore,
+    rightarg  = integer,
+    procedure = add
+);
+
+CREATE OPERATOR - (
+    leftarg   = istore,
+    rightarg  = istore,
+    procedure = subtract
+);
+
+CREATE OPERATOR - (
+    leftarg   = istore,
+    rightarg  = integer,
+    procedure = subtract
+);
+
+CREATE OPERATOR * (
+    leftarg   = istore,
+    rightarg  = istore,
+    procedure = multiply
+);
+
+CREATE OPERATOR * (
+    leftarg   = istore,
+    rightarg  = integer,
+    procedure = multiply
+);
+
+CREATE OPERATOR / (
+    leftarg   = istore,
+    rightarg  = istore,
+    procedure = divide
+);
+
+CREATE OPERATOR / (
+    leftarg   = istore,
+    rightarg  = integer,
+    procedure = divide
+);
+
+
+CREATE FUNCTION gin_extract_istore_key(internal, internal)
+RETURNS internal
+AS 'istore'
+LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION gin_extract_istore_key_query(internal, internal, int2, internal, internal)
+RETURNS internal
+AS 'istore'
+LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION gin_consistent_istore_key(internal, int2, internal, int4, internal, internal)
+RETURNS bool
+AS 'istore'
+LANGUAGE C IMMUTABLE STRICT;
+
+CREATE OPERATOR CLASS istore_key_ops
+DEFAULT FOR TYPE istore USING gin
+AS
+    OPERATOR 9 ?(istore, integer),
+    FUNCTION 1 btint4cmp(integer, integer),
+    FUNCTION 2 gin_extract_istore_key(internal, internal),
+    FUNCTION 3 gin_extract_istore_key_query(internal, internal, int2, internal, internal),
+    FUNCTION 4 gin_consistent_istore_key(internal, int2, internal, int4, internal, internal),
+    STORAGE  integer;
+ 
+--source file sql/casts.sql
+--require types
+
+CREATE FUNCTION istore(bigistore)
+    RETURNS istore
+    AS 'istore', 'bigistore_to_istore'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION bigistore(istore)
+    RETURNS bigistore
+    AS 'istore', 'istore_to_big_istore'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE CAST (istore as bigistore) WITH FUNCTION bigistore(istore) AS IMPLICIT;
+CREATE CAST (bigistore as istore) WITH FUNCTION istore(bigistore) AS ASSIGNMENT;
+ 
+--source file sql/bigistore.sql
+--require types
+
+CREATE FUNCTION exist(bigistore, integer)
+    RETURNS boolean
+    AS 'istore', 'bigistore_exist'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION fetchval(bigistore, integer)
+    RETURNS bigint
+    AS 'istore', 'bigistore_fetchval'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION each(IN is bigistore,
+    OUT key integer,
+    OUT value bigint)
+RETURNS SETOF record
+AS 'istore','bigistore_each'
+LANGUAGE C STRICT IMMUTABLE;
+
+CREATE FUNCTION compact(bigistore)
+    RETURNS bigistore
+    AS 'istore', 'bigistore_compact'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION add(bigistore, bigistore)
+    RETURNS bigistore
+    AS 'istore', 'bigistore_add'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION add(bigistore, bigint)
+    RETURNS bigistore
+    AS 'istore', 'bigistore_add_integer'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION subtract(bigistore, bigistore)
+    RETURNS bigistore
+    AS 'istore', 'bigistore_subtract'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION subtract(bigistore, bigint)
+    RETURNS bigistore
+    AS 'istore', 'bigistore_subtract_integer'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION multiply(bigistore, bigistore)
+    RETURNS bigistore
+    AS 'istore', 'bigistore_multiply'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION multiply(bigistore, bigint)
+    RETURNS bigistore
+    AS 'istore', 'bigistore_multiply_integer'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION divide(bigistore, bigistore)
+    RETURNS bigistore
+    AS 'istore', 'bigistore_divide'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION divide(bigistore, bigint)
+    RETURNS bigistore
+    AS 'istore', 'bigistore_divide_integer'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION bigistore(integer[])
+    RETURNS bigistore
+    AS 'istore', 'bigistore_from_intarray'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION sum_up(bigistore)
+    RETURNS bigint
+    AS 'istore', 'bigistore_sum_up'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION sum_up(bigistore, integer)
+    RETURNS bigint
+    AS 'istore', 'bigistore_sum_up'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION bigistore(integer[], integer[])
+    RETURNS bigistore
+    AS 'istore', 'bigistore_array_add'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION bigistore(integer[], bigint[])
+    RETURNS bigistore
+    AS 'istore', 'bigistore_array_add'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION istore(integer[], bigint[])
+    RETURNS bigistore
+    AS 'istore', 'bigistore_array_add'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION fill_gaps(bigistore, integer, bigint DEFAULT 0)
+    RETURNS bigistore
+    AS 'istore', 'bigistore_fill_gaps'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION accumulate(bigistore)
+    RETURNS bigistore
+    AS 'istore', 'bigistore_accumulate'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION accumulate(bigistore, integer)
+    RETURNS bigistore
+    AS 'istore', 'bigistore_accumulate'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION istore_seed(integer, integer, bigint)
+    RETURNS bigistore
+    AS 'istore', 'bigistore_seed'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION istore_val_larger(bigistore, bigistore)
+    RETURNS bigistore
+    AS 'istore', 'bigistore_val_larger'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION istore_val_smaller(bigistore, bigistore)
+    RETURNS bigistore
+    AS 'istore', 'bigistore_val_smaller'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION akeys(bigistore)
+    RETURNS integer[]
+    AS 'istore' ,'bigistore_akeys'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION avals(bigistore)
+    RETURNS bigint[]
+    AS 'istore' ,'bigistore_avals'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION skeys(bigistore)
+    RETURNS setof integer
+    AS 'istore' ,'bigistore_skeys'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION svals(bigistore)
+    RETURNS setof bigint
+    AS 'istore' ,'bigistore_svals'
+    LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION istore_to_json(bigistore)
+RETURNS json
+AS 'istore', 'bigistore_to_json'
+LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION istore_sum_transfn(internal, bigistore)
+    RETURNS internal
+    AS 'istore' ,'bigistore_sum_transfn'
+    LANGUAGE C IMMUTABLE;
+
+CREATE FUNCTION istore_min_transfn(internal, bigistore)
+    RETURNS internal
+    AS 'istore' ,'bigistore_min_transfn'
+    LANGUAGE C IMMUTABLE;
+
+CREATE FUNCTION istore_max_transfn(internal, bigistore)
+    RETURNS internal
+    AS 'istore' ,'bigistore_max_transfn'
+    LANGUAGE C IMMUTABLE;
+
+CREATE AGGREGATE SUM (
+    sfunc = istore_sum_transfn,
+    basetype = bigistore,
+    stype = internal,
+    finalfunc = bigistore_agg_finalfn
+);
+
+CREATE AGGREGATE MIN (
+    sfunc = istore_min_transfn,
+    basetype = bigistore,
+    stype = internal,
+    finalfunc = bigistore_agg_finalfn
+);
+
+CREATE AGGREGATE MAX (
+    sfunc = istore_max_transfn,
+    basetype = bigistore,
+    stype = internal,
+    finalfunc = bigistore_agg_finalfn
+);
+
+CREATE OPERATOR -> (
+    leftarg   = bigistore,
+    rightarg  = integer,
+    procedure = fetchval
+);
+
+CREATE OPERATOR ? (
+    leftarg   = bigistore,
+    rightarg  = integer,
+    procedure = exist
+);
+
+CREATE OPERATOR + (
+    leftarg   = bigistore,
+    rightarg  = bigistore,
+    procedure = add
+);
+
+CREATE OPERATOR + (
+    leftarg   = bigistore,
+    rightarg  = bigint,
+    procedure = add
+);
+
+CREATE OPERATOR - (
+    leftarg   = bigistore,
+    rightarg  = bigistore,
+    procedure = subtract
+);
+
+CREATE OPERATOR - (
+    leftarg   = bigistore,
+    rightarg  = bigint,
+    procedure = subtract
+);
+
+CREATE OPERATOR * (
+    leftarg   = bigistore,
+    rightarg  = bigistore,
+    procedure = multiply
+);
+
+CREATE OPERATOR * (
+    leftarg   = bigistore,
+    rightarg  = bigint,
+    procedure = multiply
+);
+
+CREATE OPERATOR / (
+    leftarg   = bigistore,
+    rightarg  = bigistore,
+    procedure = divide
+);
+
+CREATE OPERATOR / (
+    leftarg   = bigistore,
+    rightarg  = bigint,
+    procedure = divide
+);
+
+CREATE FUNCTION gin_extract_bigistore_key(internal, internal)
+RETURNS internal
+AS 'istore'
+LANGUAGE C IMMUTABLE STRICT;
+
+CREATE OPERATOR CLASS bigistore_key_ops
+DEFAULT FOR TYPE bigistore USING gin
+AS
+    OPERATOR 9 ?(bigistore, integer),
+    FUNCTION 1 btint4cmp(integer, integer),
+    FUNCTION 2 gin_extract_bigistore_key(internal, internal),
+    FUNCTION 3 gin_extract_istore_key_query(internal, internal, int2, internal, internal),
+    FUNCTION 4 gin_consistent_istore_key(internal, int2, internal, int4, internal, internal),
+    STORAGE  integer;
+ 

--- a/istore.control
+++ b/istore.control
@@ -1,6 +1,6 @@
 # istore extension
 comment = 'an integer based hstore'
-default_version = '0.1.2'
+default_version = '0.1.3'
 relocatable = true
 module_pathname = '$libdir/istore'
 requires = ''

--- a/sql/bigistore.sql
+++ b/sql/bigistore.sql
@@ -67,11 +67,6 @@ CREATE FUNCTION bigistore(integer[])
     AS 'istore', 'bigistore_from_intarray'
     LANGUAGE C IMMUTABLE STRICT;
 
-CREATE FUNCTION bigistore_agg_finalfn(internal)
-    RETURNS bigistore
-    AS 'istore'
-    LANGUAGE C IMMUTABLE STRICT;
-
 CREATE FUNCTION sum_up(bigistore)
     RETURNS bigint
     AS 'istore', 'bigistore_sum_up'
@@ -152,22 +147,40 @@ RETURNS json
 AS 'istore', 'bigistore_to_json'
 LANGUAGE C IMMUTABLE STRICT;
 
+CREATE FUNCTION istore_sum_transfn(internal, bigistore)
+    RETURNS internal
+    AS 'istore' ,'bigistore_sum_transfn'
+    LANGUAGE C IMMUTABLE;
+
+CREATE FUNCTION istore_min_transfn(internal, bigistore)
+    RETURNS internal
+    AS 'istore' ,'bigistore_min_transfn'
+    LANGUAGE C IMMUTABLE;
+
+CREATE FUNCTION istore_max_transfn(internal, bigistore)
+    RETURNS internal
+    AS 'istore' ,'bigistore_max_transfn'
+    LANGUAGE C IMMUTABLE;
 
 CREATE AGGREGATE SUM (
-    sfunc = array_agg_transfn,
+    sfunc = istore_sum_transfn,
     basetype = bigistore,
     stype = internal,
     finalfunc = bigistore_agg_finalfn
 );
 
-CREATE AGGREGATE MIN(bigistore) (
-    sfunc = istore_val_smaller,
-    stype = bigistore
+CREATE AGGREGATE MIN (
+    sfunc = istore_min_transfn,
+    basetype = bigistore,
+    stype = internal,
+    finalfunc = bigistore_agg_finalfn
 );
 
-CREATE AGGREGATE MAX(bigistore) (
-    sfunc = istore_val_larger,
-    stype = bigistore
+CREATE AGGREGATE MAX (
+    sfunc = istore_max_transfn,
+    basetype = bigistore,
+    stype = internal,
+    finalfunc = bigistore_agg_finalfn
 );
 
 CREATE OPERATOR -> (

--- a/sql/istore.sql
+++ b/sql/istore.sql
@@ -67,11 +67,6 @@ CREATE FUNCTION istore(integer[])
     AS 'istore', 'istore_from_intarray'
     LANGUAGE C IMMUTABLE STRICT;
 
-CREATE FUNCTION istore_agg_finalfn(internal)
-    RETURNS bigistore
-    AS 'istore'
-    LANGUAGE C IMMUTABLE STRICT;
-
 CREATE FUNCTION sum_up(istore)
     RETURNS bigint
     AS 'istore', 'istore_sum_up'
@@ -137,26 +132,55 @@ CREATE FUNCTION svals(istore)
     AS 'istore' ,'istore_svals'
     LANGUAGE C IMMUTABLE STRICT;
 
+CREATE FUNCTION istore_sum_transfn(internal, istore)
+    RETURNS internal
+    AS 'istore' ,'istore_sum_transfn'
+    LANGUAGE C IMMUTABLE;
+
+CREATE FUNCTION istore_min_transfn(internal, istore)
+    RETURNS internal
+    AS 'istore'
+    LANGUAGE C IMMUTABLE;
+
+CREATE FUNCTION istore_max_transfn(internal, istore)
+    RETURNS internal
+    AS 'istore'
+    LANGUAGE C IMMUTABLE;
+
+CREATE FUNCTION istore_agg_finalfn_pairs(internal)
+    RETURNS istore
+    AS 'istore' ,'istore_agg_finalfn_pairs'
+    LANGUAGE C IMMUTABLE STRICT;
+
 CREATE FUNCTION istore_to_json(istore)
 RETURNS json
 AS 'istore', 'istore_to_json'
 LANGUAGE C IMMUTABLE STRICT;
 
+CREATE FUNCTION bigistore_agg_finalfn(internal)
+    RETURNS bigistore
+    AS 'istore' ,'bigistore_agg_finalfn_pairs'
+    LANGUAGE C IMMUTABLE STRICT;
+
 CREATE AGGREGATE SUM (
-    sfunc = array_agg_transfn,
+    sfunc = istore_sum_transfn,
     basetype = istore,
     stype = internal,
-    finalfunc = istore_agg_finalfn
+    finalfunc = bigistore_agg_finalfn
 );
 
-CREATE AGGREGATE MIN(istore) (
-    sfunc = istore_val_smaller,
-    stype = istore
+CREATE AGGREGATE MIN (
+    sfunc = istore_min_transfn,
+    basetype = istore,
+    stype = internal,
+    finalfunc = istore_agg_finalfn_pairs
 );
 
-CREATE AGGREGATE MAX(istore) (
-    sfunc = istore_val_larger,
-    stype = istore
+CREATE AGGREGATE MAX (
+    sfunc = istore_max_transfn,
+    basetype = istore,
+    stype = internal,
+    finalfunc = istore_agg_finalfn_pairs
 );
 
 CREATE OPERATOR -> (

--- a/src/bigistore.c
+++ b/src/bigistore.c
@@ -444,39 +444,6 @@ bigistore_from_intarray(PG_FUNCTION_ARGS)
 }
 
 /*
- * sum aggregation final function
- */
-PG_FUNCTION_INFO_V1(bigistore_agg_finalfn);
-Datum
-bigistore_agg_finalfn(PG_FUNCTION_ARGS)
-{
-    Datum            result;
-    ArrayBuildState *input;
-    Datum           *data;
-    bool            *nulls;
-    int              count;
-
-    if (PG_ARGISNULL(0))
-        PG_RETURN_NULL();
-    Assert(AggCheckCallContext(fcinfo, NULL));
-
-    input = (ArrayBuildState *) PG_GETARG_POINTER(0);
-    count = input->nelems;
-    nulls = input->dnulls;
-    data  = input->dvalues;
-
-    if (count == 0)
-        PG_RETURN_NULL();
-
-    result = bigistore_array_sum(data, count, nulls);
-
-    if (result == 0)
-        PG_RETURN_NULL();
-    else
-        return result;
-}
-
-/*
  * bigistore from key and value intarrays
  * bot arrays must have the same length, NULLs are omitted
  * duplicate keys result in added values

--- a/src/depcode.c
+++ b/src/depcode.c
@@ -1,0 +1,182 @@
+#include "istore.h"
+#include "funcapi.h"
+#include "utils/array.h"
+
+
+/*
+ * Depricated code that is only needed for downgarde compatibility lives here
+ */
+
+
+Datum istore_array_sum(Datum *data, int count, bool *nulls);
+Datum bigistore_array_sum(Datum *data, int count, bool *nulls);
+
+/*
+ * sum aggregation final function
+ */
+PG_FUNCTION_INFO_V1(bigistore_agg_finalfn);
+Datum
+bigistore_agg_finalfn(PG_FUNCTION_ARGS)
+{
+    Datum            result;
+    ArrayBuildState *input;
+    Datum           *data;
+    bool            *nulls;
+    int              count;
+
+    if (PG_ARGISNULL(0))
+        PG_RETURN_NULL();
+    Assert(AggCheckCallContext(fcinfo, NULL));
+
+    input = (ArrayBuildState *) PG_GETARG_POINTER(0);
+    count = input->nelems;
+    nulls = input->dnulls;
+    data  = input->dvalues;
+
+    if (count == 0)
+        PG_RETURN_NULL();
+ 
+    result = bigistore_array_sum(data, count, nulls);
+ 
+    if (result == 0)
+        PG_RETURN_NULL();
+    else
+        return result;
+}
+
+
+PG_FUNCTION_INFO_V1(istore_agg_finalfn);
+Datum
+istore_agg_finalfn(PG_FUNCTION_ARGS)
+{
+    Datum            result;
+    ArrayBuildState *input;
+    Datum           *data;
+    bool            *nulls;
+    int              count;
+
+    if (PG_ARGISNULL(0))
+        PG_RETURN_NULL();
+    Assert(AggCheckCallContext(fcinfo, NULL));
+
+    input = (ArrayBuildState *) PG_GETARG_POINTER(0);
+    count = input->nelems;
+    nulls = input->dnulls;
+    data  = input->dvalues;
+
+    if (count == 0)
+        PG_RETURN_NULL();
+
+    result = istore_array_sum(data, count, nulls);
+
+    if (result == 0)
+        PG_RETURN_NULL();
+    else
+        return result;
+}
+
+
+ 
+/*
+ * summarize an array of istores
+ */
+Datum
+istore_array_sum(Datum *data, int count, bool *nulls)
+{
+    BigIStore       *out;
+    IStore          *istore;
+    AvlNode         *tree;
+    IStorePair      *payload;
+    BigIStorePairs  *pairs;
+    AvlNode         *position;
+    int              i,
+                     n,
+                     index;
+
+
+    tree = NULL;
+    n    = 0;
+
+    for (i = 0; i < count; ++i)
+    {
+        if (nulls[i])
+            continue;
+
+        istore = (IStore *) data[i];
+        payload = FIRST_PAIR(istore, IStorePair);
+        for (index = 0; index < istore->len; ++index)
+        {
+            position = is_tree_find(payload[index].key, tree);
+            if (position == NULL)
+            {
+                tree = is_tree_insert(tree, payload[index].key, payload[index].val);
+                ++n;
+            }
+            else{
+                position->value += payload[index].val;
+            }
+        }
+    }
+
+    if (n == 0)
+        return 0;
+    pairs = palloc0(sizeof *pairs);
+    bigistore_pairs_init(pairs, n);
+    bigistore_tree_to_pairs(tree, pairs);
+    istore_make_empty(tree);
+
+    FINALIZE_BIGISTORE(out, pairs);
+    PG_RETURN_POINTER(out);
+}
+
+/*
+ * summarize an array of bigistores
+ */
+Datum
+bigistore_array_sum(Datum *data, int count, bool *nulls)
+{
+    BigIStore       *out;
+    BigIStore       *istore;
+    AvlNode         *tree;
+    BigIStorePair   *payload;
+    BigIStorePairs  *pairs;
+    AvlNode         *position;
+    int              i,
+                     n,
+                     index;
+
+
+    tree = NULL;
+    n    = 0;
+
+    for (i = 0; i < count; ++i)
+    {
+        if (nulls[i])
+            continue;
+
+        istore = (BigIStore *) data[i];
+        payload = FIRST_PAIR(istore, BigIStorePair);
+        for (index = 0; index < istore->len; ++index)
+        {
+            position = is_tree_find(payload[index].key, tree);
+            if (position == NULL)
+            {
+                tree = is_tree_insert(tree, payload[index].key, payload[index].val);
+                ++n;
+            }
+            else{
+                position->value = DirectFunctionCall2(int8pl, position->value, payload[index].val);
+            }
+        }
+    }
+
+    if (n == 0)
+        return 0;
+    pairs = palloc0(sizeof *pairs);
+    bigistore_pairs_init(pairs, n);
+    bigistore_tree_to_pairs(tree, pairs);
+    istore_make_empty(tree);
+
+    FINALIZE_BIGISTORE(out, pairs);
+    PG_RETURN_POINTER(out);
+}

--- a/src/istore.c
+++ b/src/istore.c
@@ -447,39 +447,6 @@ istore_from_intarray(PG_FUNCTION_ARGS)
 }
 
 /*
- * sum aggregation final function
- */
-PG_FUNCTION_INFO_V1(istore_agg_finalfn);
-Datum
-istore_agg_finalfn(PG_FUNCTION_ARGS)
-{
-    Datum            result;
-    ArrayBuildState *input;
-    Datum           *data;
-    bool            *nulls;
-    int              count;
-
-    if (PG_ARGISNULL(0))
-        PG_RETURN_NULL();
-    Assert(AggCheckCallContext(fcinfo, NULL));
-
-    input = (ArrayBuildState *) PG_GETARG_POINTER(0);
-    count = input->nelems;
-    nulls = input->dnulls;
-    data  = input->dvalues;
-
-    if (count == 0)
-        PG_RETURN_NULL();
-
-    result = istore_array_sum(data, count, nulls);
-
-    if (result == 0)
-        PG_RETURN_NULL();
-    else
-        return result;
-}
-
-/*
  * istore from key and value intarrays
  * bot arrays must have the same length, NULLs are omitted
  * duplicate keys result in added values

--- a/src/istore.h
+++ b/src/istore.h
@@ -12,7 +12,6 @@ Datum istore_recv(PG_FUNCTION_ARGS);
 Datum istore_send(PG_FUNCTION_ARGS);
 Datum istore_to_json(PG_FUNCTION_ARGS);
 Datum istore_array_add(PG_FUNCTION_ARGS);
-Datum istore_agg_finalfn(PG_FUNCTION_ARGS);
 Datum istore_from_intarray(PG_FUNCTION_ARGS);
 Datum istore_multiply_integer(PG_FUNCTION_ARGS);
 Datum istore_multiply(PG_FUNCTION_ARGS);
@@ -32,12 +31,13 @@ Datum istore_accumulate(PG_FUNCTION_ARGS);
 Datum istore_seed(PG_FUNCTION_ARGS);
 Datum istore_val_larger(PG_FUNCTION_ARGS);
 Datum istore_val_smaller(PG_FUNCTION_ARGS);
-Datum istore_array_sum(Datum *data, int count, bool *nulls);
 Datum istore_compact(PG_FUNCTION_ARGS);
 Datum istore_akeys(PG_FUNCTION_ARGS);
 Datum istore_avals(PG_FUNCTION_ARGS);
 Datum istore_skeys(PG_FUNCTION_ARGS);
 Datum istore_svals(PG_FUNCTION_ARGS);
+Datum istore_sum_transfn(PG_FUNCTION_ARGS);
+Datum istore_sum_finalfn(PG_FUNCTION_ARGS);
 
 Datum bigistore_out(PG_FUNCTION_ARGS);
 Datum bigistore_in(PG_FUNCTION_ARGS);
@@ -45,7 +45,6 @@ Datum bigistore_recv(PG_FUNCTION_ARGS);
 Datum bigistore_send(PG_FUNCTION_ARGS);
 Datum bigistore_to_json(PG_FUNCTION_ARGS);
 Datum bigistore_array_add(PG_FUNCTION_ARGS);
-Datum bigistore_agg_finalfn(PG_FUNCTION_ARGS);
 Datum bigistore_from_intarray(PG_FUNCTION_ARGS);
 Datum bigistore_multiply_integer(PG_FUNCTION_ARGS);
 Datum bigistore_multiply(PG_FUNCTION_ARGS);
@@ -65,12 +64,12 @@ Datum bigistore_accumulate(PG_FUNCTION_ARGS);
 Datum bigistore_seed(PG_FUNCTION_ARGS);
 Datum bigistore_val_larger(PG_FUNCTION_ARGS);
 Datum bigistore_val_smaller(PG_FUNCTION_ARGS);
-Datum bigistore_array_sum(Datum *data, int count, bool *nulls);
 Datum bigistore_compact(PG_FUNCTION_ARGS);
 Datum bigistore_akeys(PG_FUNCTION_ARGS);
 Datum bigistore_avals(PG_FUNCTION_ARGS);
 Datum bigistore_skeys(PG_FUNCTION_ARGS);
 Datum bigistore_svals(PG_FUNCTION_ARGS);
+Datum bigistore_sum_transfn(PG_FUNCTION_ARGS);
 
 /*
  * a single key/value pair
@@ -126,6 +125,8 @@ IStore* istore_apply_datum(IStore *arg1, Datum arg2, PGFunction applyfunc);
 BigIStore* bigistore_merge(BigIStore *arg1, BigIStore *arg2, PGFunction mergefunc, PGFunction miss1func);
 BigIStore* bigistore_apply_datum(BigIStore *arg1, Datum arg2, PGFunction applyfunc);
 
+void istore_copy_and_add_buflen(IStore *istore, BigIStorePair *pairs);
+void bigistore_add_buflen(BigIStore *istore);
 void istore_pairs_init(IStorePairs *pairs, size_t initial_size);
 void istore_pairs_insert(IStorePairs *pairs, int32 key, int32 val);
 int  istore_pairs_cmp(const void *a, const void *b);

--- a/src/istore_agg.c
+++ b/src/istore_agg.c
@@ -1,106 +1,383 @@
 #include "istore.h"
-#include "istore.h"
 
-/*
- * summarize an array of istores
- */
-Datum
-istore_array_sum(Datum *data, int count, bool *nulls)
+#define SAMESIGN(a,b)   (((a) < 0) == ((b) < 0))
+#define INITSTATESIZE 30
+
+#define BIG_ISTORE 1
+#define ISTORE 0
+
+#define INIT_AGG_STATE(_state)                                                                 \
+    do {                                                                                         \
+        MemoryContext  agg_context;                                                              \
+                                                                                                 \
+        if (!AggCheckCallContext(fcinfo, &agg_context))                                          \
+            elog(ERROR, "aggregate function called in non-aggregate context");                   \
+                                                                                                 \
+        if (PG_ARGISNULL(1) && PG_ARGISNULL(0)) PG_RETURN_NULL();                                \
+                                                                                                 \
+        _state = PG_ARGISNULL(0) ? state_init(agg_context) : (ISAggState *) PG_GETARG_POINTER(0);\
+                                                                                                 \
+        if (PG_ARGISNULL(1)) PG_RETURN_POINTER(_state);                                          \
+                                                                                                 \
+    } while(0)
+
+typedef struct {
+    size_t size;
+    int    used;
+    BigIStorePair pairs[0];
+} ISAggState;
+
+typedef enum {
+    AGG_SUM,
+    AGG_MIN,
+    AGG_MAX
+} ISAggType;
+
+static inline ISAggState *
+state_init(MemoryContext agg_context)
 {
-    BigIStore       *out;
-    IStore          *istore;
-    AvlNode         *tree;
-    IStorePair      *payload;
-    BigIStorePairs  *pairs;
-    AvlNode         *position;
-    int              i,
-                     n,
-                     index;
+    ISAggState *state;
+    state = (ISAggState *) MemoryContextAllocZero(agg_context, sizeof(ISAggState) + INITSTATESIZE * sizeof(BigIStorePair));
+    state->size = INITSTATESIZE ;
+    return state;
+}
 
+// Aggregate internal function for istore.
+static inline ISAggState *
+istore_agg_internal(ISAggState *state, IStore *istore, ISAggType type)
+{
+    BigIStorePair *pairs1;
+    IStorePair    *pairs2;
+    int            index1 = 0,
+                   index2 = 0;
 
-    tree = NULL;
-    n    = 0;
-
-    for (i = 0; i < count; ++i)
+    pairs1 = state->pairs;
+    pairs2 = FIRST_PAIR(istore, IStorePair);
+    while (index1 < state->used && index2 < istore->len)
     {
-        if (nulls[i])
-            continue;
-
-        istore = (IStore *) data[i];
-        payload = FIRST_PAIR(istore, IStorePair);
-        for (index = 0; index < istore->len; ++index)
+        if (pairs1->key < pairs2->key)
         {
-            position = is_tree_find(payload[index].key, tree);
-            if (position == NULL)
+            // do nothing keep state
+            ++pairs1;
+            ++index1;
+        }
+        else if (pairs1->key > pairs2->key)
+        {
+            int i = 1;
+            while(index2 + i < istore->len && pairs1->key > pairs2[i].key){
+                ++i;
+            }
+
+            // ensure array is big enough
+            if (state->size < state->used + i)
             {
-                tree = is_tree_insert(tree, payload[index].key, payload[index].val);
-                ++n;
+                state->size  = state->size * 2 > state->used + i ? state->size * 2 : state->used + i;
+                state        = repalloc(state, sizeof(ISAggState) + state->size * sizeof(BigIStorePair));
+                pairs1       = state->pairs+index1;
             }
-            else{
-                position->value += payload[index].val;
+
+            // move data i steps forward from index1
+            memmove(pairs1+i,pairs1, (state->used - index1) * sizeof(BigIStorePair));
+            // copy data
+            state->used += i;
+            // we can't use memcpy here as pairs1 and pairs2 differ in type
+            for (int j=0; j<i; j++)
+            {
+                pairs1->key = pairs2->key;
+                pairs1->val = pairs2->val;
+                ++pairs1;
+                ++pairs2;
             }
+            index1+=i;
+            index2+=i;
+
+        }
+        else
+        {
+            // identical keys add values
+            if (type == AGG_SUM)
+            {
+                /*
+                * Overflow check.  If the inputs are of different signs then their sum
+                * cannot overflow.  If the inputs are of the same sign, their sum had
+                * better be that sign too.
+                */
+                if (SAMESIGN(pairs1->val, pairs2->val))
+                {
+                    pairs1->val += pairs2->val;
+                    if(!SAMESIGN(pairs1->val, pairs2->val))
+                        ereport(ERROR,
+                                (errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
+                                errmsg("bigint out of range")));
+                }
+                else
+                {
+                    pairs1->val += pairs2->val;
+                }
+            }
+            else if (type == AGG_MIN)
+            {
+                pairs1->val = MIN(pairs2->val, pairs1->val);
+            }
+            else if (type == AGG_MAX)
+            {
+                pairs1->val = MAX(pairs2->val, pairs1->val);
+            }
+
+            ++index1;
+            ++index2;
+            ++pairs1;
+            ++pairs2;
         }
     }
 
-    if (n == 0)
-        return 0;
-    pairs = palloc0(sizeof *pairs);
-    bigistore_pairs_init(pairs, n);
-    bigistore_tree_to_pairs(tree, pairs);
-    istore_make_empty(tree);
+    // append any leftovers
+    int i = istore->len - index2;
+    if ( i > 0 )
+    {
+        if (state->size <= state->used + i)
+        {
+            state->size = state->size * 2 > state->used + i ? state->size * 2 : state->used + i;
+            state       = repalloc(state, sizeof(ISAggState) + state->size * sizeof(BigIStorePair));
+            pairs1      = state->pairs+index1;
+        }
+        state->used += i;
+        // we can't use memcpy here as pairs1 and pairs2 differ in type
+        for (int j=0; j<i; j++)
+        {
+            pairs1->key = pairs2->key;
+            pairs1->val = pairs2->val;
+            ++pairs1;
+            ++pairs2;
+        }
+    }
 
-    FINALIZE_BIGISTORE(out, pairs);
-    PG_RETURN_POINTER(out);
+    return state;
+}
+
+static inline ISAggState *
+bigistore_agg_internal(ISAggState *state, BigIStore *istore, ISAggType type)
+{
+    BigIStorePair *pairs2;
+    BigIStorePair *pairs1;
+    int            index1 = 0,
+                   index2 = 0;
+
+    pairs1 = state->pairs;
+    pairs2 = FIRST_PAIR(istore, BigIStorePair);
+    while (index1 < state->used && index2 < istore->len)
+    {
+        if (pairs1->key < pairs2->key)
+        {
+            // do nothing keep state
+            ++pairs1;
+            ++index1;
+        }
+        else if (pairs1->key > pairs2->key)
+        {
+            int i = 1;
+            while(index2 + i < istore->len && pairs1->key > pairs2[i].key){
+                ++i;
+            }
+
+            // ensure array is big enough
+            if (state->size < state->used + i)
+            {
+                state->size  = state->size * 2 > state->used + i ? state->size * 2 : state->used + i;
+                state        = repalloc(state, sizeof(ISAggState) + state->size * sizeof(BigIStorePair));
+                pairs1       = state->pairs+index1;
+            }
+
+            // move data i steps forward from index1
+            memmove(pairs1+i,pairs1, (state->used - index1) * sizeof(BigIStorePair));
+
+            // copy data
+            state->used += i;
+            memcpy(pairs1, pairs2, i * sizeof(BigIStorePair));
+            pairs1 += i;
+            pairs2 += i;
+            index1 += i;
+            index2 += i;
+
+        }
+        else
+        {
+            // identical keys - apply logic according to aggregation type
+            if (type == AGG_SUM)
+            {
+                    /*
+                    * Overflow check.  If the inputs are of different signs then their sum
+                    * cannot overflow.  If the inputs are of the same sign, their sum had
+                    * better be that sign too.
+                    */
+                    if (SAMESIGN(pairs1->val, pairs2->val))
+                    {
+                        pairs1->val += pairs2->val;
+                        if(!SAMESIGN(pairs1->val, pairs2->val))
+                            ereport(ERROR,
+                                    (errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
+                                    errmsg("bigint out of range")));
+                    }
+                    else
+                    {
+                        pairs1->val += pairs2->val;
+                    }
+            }
+            else if (type == AGG_MIN)
+            {
+                pairs1->val = MIN(pairs2->val, pairs1->val);
+            }
+            else if (type == AGG_MAX)
+            {
+                pairs1->val = MAX(pairs2->val, pairs1->val);
+            }
+
+            ++index1;
+            ++index2;
+            ++pairs1;
+            ++pairs2;
+        }
+    }
+
+    // append any leftovers
+    int i = istore->len - index2;
+    if ( i > 0 )
+    {
+        if (state->size <= state->used + i)
+        {
+            state->size = state->size * 2 > state->used + i ? state->size * 2 : state->used + i;
+            state       = repalloc(state, sizeof(ISAggState) + state->size * sizeof(BigIStorePair));
+            pairs1      = state->pairs+index1;
+        }
+        state->used += i;
+        memcpy(pairs1,pairs2, i * sizeof(BigIStorePair));
+    }
+
+    return state;
 }
 
 /*
- * summarize an array of bigistores
+ * MIN(istore) aggregate funtion
  */
+PG_FUNCTION_INFO_V1(istore_min_transfn);
 Datum
-bigistore_array_sum(Datum *data, int count, bool *nulls)
+istore_min_transfn(PG_FUNCTION_ARGS)
 {
-    BigIStore       *out;
-    BigIStore       *istore;
-    AvlNode         *tree;
-    BigIStorePair   *payload;
-    BigIStorePairs  *pairs;
-    AvlNode         *position;
-    int              i,
-                     n,
-                     index;
+    ISAggState    *state;
+    INIT_AGG_STATE(state);
 
+    PG_RETURN_POINTER(istore_agg_internal(state, PG_GETARG_IS(1), AGG_MIN));
+}
 
-    tree = NULL;
-    n    = 0;
+/*
+ * MIN(bigistore) aggregate funtion
+ */
+PG_FUNCTION_INFO_V1(bigistore_min_transfn);
+Datum
+bigistore_min_transfn(PG_FUNCTION_ARGS)
+{
+    ISAggState    *state;
+    INIT_AGG_STATE(state);
+    PG_RETURN_POINTER(bigistore_agg_internal(state, PG_GETARG_BIGIS(1), AGG_MIN));
+}
 
-    for (i = 0; i < count; ++i)
-    {
-        if (nulls[i])
-            continue;
+/*
+ * MAX(istore) aggregate funtion
+ */
+PG_FUNCTION_INFO_V1(istore_max_transfn);
+Datum
+istore_max_transfn(PG_FUNCTION_ARGS)
+{
+    ISAggState    *state;
+    INIT_AGG_STATE(state);
+    PG_RETURN_POINTER(istore_agg_internal(state, PG_GETARG_IS(1), AGG_MAX));
 
-        istore = (BigIStore *) data[i];
-        payload = FIRST_PAIR(istore, BigIStorePair);
-        for (index = 0; index < istore->len; ++index)
-        {
-            position = is_tree_find(payload[index].key, tree);
-            if (position == NULL)
-            {
-                tree = is_tree_insert(tree, payload[index].key, payload[index].val);
-                ++n;
-            }
-            else{
-                position->value = DirectFunctionCall2(int8pl, position->value, payload[index].val);
-            }
-        }
-    }
+}
 
-    if (n == 0)
-        return 0;
-    pairs = palloc0(sizeof *pairs);
-    bigistore_pairs_init(pairs, n);
-    bigistore_tree_to_pairs(tree, pairs);
-    istore_make_empty(tree);
+/*
+ * MAX(bigistore) aggregate funtion
+ */
+PG_FUNCTION_INFO_V1(bigistore_max_transfn);
+Datum
+bigistore_max_transfn(PG_FUNCTION_ARGS)
+{
+    ISAggState    *state;
+    INIT_AGG_STATE(state);
+    PG_RETURN_POINTER(bigistore_agg_internal(state, PG_GETARG_BIGIS(1), AGG_MAX));
 
-    FINALIZE_BIGISTORE(out, pairs);
-    PG_RETURN_POINTER(out);
+}
+
+/*
+ * SUM(istore) aggregate funtion
+ */
+PG_FUNCTION_INFO_V1(istore_sum_transfn);
+Datum
+istore_sum_transfn(PG_FUNCTION_ARGS)
+{
+    ISAggState    *state;
+    INIT_AGG_STATE(state);
+    PG_RETURN_POINTER(istore_agg_internal(state, PG_GETARG_IS(1), AGG_SUM));
+
+}
+
+/*
+ * SUM(bigistore) aggregate funtion
+ */
+PG_FUNCTION_INFO_V1(bigistore_sum_transfn);
+Datum
+bigistore_sum_transfn(PG_FUNCTION_ARGS)
+{
+    ISAggState    *state;
+    INIT_AGG_STATE(state);
+    PG_RETURN_POINTER(bigistore_agg_internal(state, PG_GETARG_BIGIS(1), AGG_SUM));
+
+}
+
+/*
+ * Final function for SUM(istore/bigistore) and MIN/MAX(bigistore)
+ * Both SUM transition functions return the same transition type - the same as
+ * MIN/MAX(bigistore).
+ */
+PG_FUNCTION_INFO_V1(bigistore_agg_finalfn_pairs);
+Datum
+bigistore_agg_finalfn_pairs(PG_FUNCTION_ARGS)
+{
+    ISAggState  *state;
+    BigIStore   *istore;
+
+    if (PG_ARGISNULL(0)) PG_RETURN_NULL();
+
+    state       = (ISAggState *) PG_GETARG_POINTER(0);
+    istore      = (BigIStore *)(palloc0(ISHDRSZ + state->used * sizeof(BigIStorePair)));
+    istore->len = state->used;
+
+    memcpy(FIRST_PAIR(istore, BigIStorePair), state->pairs, state->used * sizeof(BigIStorePair));
+    bigistore_add_buflen(istore);
+
+    SET_VARSIZE(istore, ISHDRSZ + state->used * sizeof(BigIStorePair));
+
+    PG_RETURN_POINTER(istore);
+}
+
+/*
+ * Final function for MIN/MAX(istore)
+ */
+PG_FUNCTION_INFO_V1(istore_agg_finalfn_pairs);
+Datum
+istore_agg_finalfn_pairs(PG_FUNCTION_ARGS)
+{
+    ISAggState *state;
+    IStore     *istore;
+
+    if (PG_ARGISNULL(0)) PG_RETURN_NULL();
+
+    state       = (ISAggState *) PG_GETARG_POINTER(0);
+    istore      = (IStore *)(palloc0(ISHDRSZ + state->used * sizeof(IStorePair)));
+    istore->len = state->used;
+
+    istore_copy_and_add_buflen(istore, state->pairs);
+
+    SET_VARSIZE(istore, ISHDRSZ + state->used * sizeof(IStorePair));
+
+    PG_RETURN_POINTER(istore);
 }

--- a/src/pairs.c
+++ b/src/pairs.c
@@ -6,6 +6,42 @@ static inline int digits32(int32 num);
 static inline int digits64(int64 num);
 
 /*
+ * copy *src_pairs to the IStorePair of *istore and add buflen to *istore
+ */
+void
+istore_copy_and_add_buflen(IStore *istore, BigIStorePair *src_pairs)
+{
+    IStorePair *dest_pairs = FIRST_PAIR(istore, IStorePair);
+
+    for (int i = 0; i < istore->len; ++i)
+    {
+        dest_pairs[i].key = src_pairs[i].key;
+        dest_pairs[i].val = src_pairs[i].val;
+        istore->buflen += digits32(dest_pairs[i].key) + digits32(dest_pairs[i].val) + BUFLEN_OFFSET;
+    }
+
+    if (istore->buflen < 0)
+        elog(ERROR, "istore buffer overflow");
+}
+
+/*
+ * add buflen to bigistore
+ */
+void
+bigistore_add_buflen(BigIStore *istore)
+{
+    BigIStorePair  *pairs;
+
+    pairs  = FIRST_PAIR(istore, BigIStorePair);
+
+    for(int i = 0; i < istore->len; i++)
+        istore->buflen += digits32(pairs[i].key) + digits64(pairs[i].val) + BUFLEN_OFFSET;
+
+    if (istore->buflen < 0)
+        elog(ERROR, "istore buffer overflow");
+}
+
+/*
  * adds a key/ value pair for each subnode to IStorePairs
  * due to the nature of the AVL tree the pairs will be ordered by key
  */

--- a/travis.sh
+++ b/travis.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+make && make install && make installcheck
+RESULT=$?
+if test -f regression.diffs; then cat regression.diffs; fi
+exit $RESULT


### PR DESCRIPTION
Changes the istore SUM aggregate function to use an array of pairs
rather than an array of istores as transition state.
This gives a significant performance boost of about 20%-30% when aggregating
a large ammount of istores.
We now also have an overflow check when aggregating istores. As the state/result
is of type bigistore overflow is unlikely to happen (only if more than INT_MAX elements
get aggregated). The old implementation could assume that this will never happen
as MaxAllocSize would have been reached before which is not the case anymore.

Old depricated code lives in src/depcode.c to make upgrade/downgrade still
possible.
