### PR TITLE
Refactor MIN/MAX aggregate functions for istore and bigistore

### DIFF
--- a/istore--0.1.1--0.1.2.sql
+++ b/istore--0.1.1--0.1.2.sql
@@ -1,38 +1,107 @@
 ----functions----
+CREATE FUNCTION istore_agg_finalfn_pairs(internal)
+ RETURNS istore
+ LANGUAGE c
+ IMMUTABLE STRICT
+AS 'istore', $function$istore_agg_finalfn_pairs$function$;
+
+CREATE OR REPLACE FUNCTION bigistore_agg_finalfn(internal)
+ RETURNS bigistore
+ LANGUAGE c
+ IMMUTABLE STRICT
+AS 'istore', $function$bigistore_agg_finalfn_pairs$function$;
+
+CREATE FUNCTION istore_max_transfn(internal, bigistore)
+ RETURNS internal
+ LANGUAGE c
+ IMMUTABLE
+AS 'istore', $function$bigistore_max_transfn$function$;
+
+----
+CREATE FUNCTION istore_min_transfn(internal, bigistore)
+ RETURNS internal
+ LANGUAGE c
+ IMMUTABLE
+AS 'istore', $function$bigistore_min_transfn$function$;
+
+----
 CREATE OR REPLACE FUNCTION istore_sum_transfn(internal, bigistore)
  RETURNS internal
  LANGUAGE c
  IMMUTABLE
 AS 'istore', $function$bigistore_sum_transfn$function$;
+
 ----
-CREATE OR REPLACE FUNCTION istore_sum_finalfn(internal)
- RETURNS bigistore
+CREATE FUNCTION istore_max_transfn(internal, istore)
+ RETURNS internal
  LANGUAGE c
- IMMUTABLE STRICT
-AS 'istore', $function$istore_sum_finalfn$function$;
+ IMMUTABLE
+AS 'istore', $function$istore_max_transfn$function$;
+
+----
+CREATE FUNCTION istore_min_transfn(internal, istore)
+ RETURNS internal
+ LANGUAGE c
+ IMMUTABLE
+AS 'istore', $function$istore_min_transfn$function$;
+
 ----
 CREATE OR REPLACE FUNCTION istore_sum_transfn(internal, istore)
  RETURNS internal
  LANGUAGE c
  IMMUTABLE
 AS 'istore', $function$istore_sum_transfn$function$;
+
 ----aggregates----
 DROP AGGREGATE IF EXISTS sum (bigistore);
 CREATE AGGREGATE sum(bigistore) (
   SFUNC = public.istore_sum_transfn,
   STYPE = internal,
-  FINALFUNC = istore_sum_finalfn
+  FINALFUNC = bigistore_agg_finalfn
 );
-
 
 ----
 DROP AGGREGATE IF EXISTS sum (istore);
 CREATE AGGREGATE sum(istore) (
   SFUNC = public.istore_sum_transfn,
   STYPE = internal,
-  FINALFUNC = istore_sum_finalfn
+  FINALFUNC = bigistore_agg_finalfn
 );
 
-----functions----
+----
+DROP AGGREGATE IF EXISTS MIN (istore);
+CREATE AGGREGATE MIN (
+    sfunc = istore_min_transfn,
+    basetype = istore,
+    stype = internal,
+    finalfunc = istore_agg_finalfn_pairs
+);
+
+----
+DROP AGGREGATE IF EXISTS MAX (istore);
+CREATE AGGREGATE MAX (
+    sfunc = istore_max_transfn,
+    basetype = istore,
+    stype = internal,
+    finalfunc = istore_agg_finalfn_pairs
+);
+
+----
+DROP AGGREGATE IF EXISTS MIN (bigistore);
+CREATE AGGREGATE MIN (
+    sfunc = istore_min_transfn,
+    basetype = bigistore,
+    stype = internal,
+    finalfunc = bigistore_agg_finalfn
+);
+
+----
+DROP AGGREGATE IF EXISTS MAX (bigistore);
+CREATE AGGREGATE MAX (
+    sfunc = istore_max_transfn,
+    basetype = bigistore,
+    stype = internal,
+    finalfunc = bigistore_agg_finalfn
+);
+
 DROP FUNCTION IF EXISTS istore_agg_finalfn(internal);
-DROP FUNCTION IF EXISTS bigistore_agg_finalfn(internal);

--- a/istore--0.1.2--0.1.1.sql
+++ b/istore--0.1.2--0.1.1.sql
@@ -9,13 +9,26 @@ CREATE OR REPLACE FUNCTION istore_agg_finalfn(internal)
     LANGUAGE C IMMUTABLE STRICT;
 
 ----aggregates----
+DROP AGGREGATE IF EXISTS MIN (istore);
+CREATE AGGREGATE MIN(istore) (
+    sfunc = istore_val_smaller,
+    stype = istore
+);
+
+----
+DROP AGGREGATE IF EXISTS MAX (istore);
+CREATE AGGREGATE MAX(istore) (
+    sfunc = istore_val_larger,
+    stype = istore
+);
+
+----
 DROP AGGREGATE IF EXISTS sum (bigistore);
 CREATE AGGREGATE sum(bigistore) (
   SFUNC = array_agg_transfn,
   STYPE = internal,
   FINALFUNC = bigistore_agg_finalfn
 );
-
 
 ----
 DROP AGGREGATE IF EXISTS sum (istore);
@@ -25,10 +38,37 @@ CREATE AGGREGATE sum(istore) (
   FINALFUNC = istore_agg_finalfn
 );
 
+----
+DROP AGGREGATE IF EXISTS MIN (bigistore);
+CREATE AGGREGATE MIN(bigistore) (
+    sfunc = istore_val_smaller,
+    stype = bigistore
+);
 
 ----functions----
-DROP FUNCTION IF EXISTS istore_sum_transfn(internal, bigistore);
+DROP FUNCTION istore_sum_transfn(internal, bigistore);
+
 ----
-DROP FUNCTION IF EXISTS istore_sum_finalfn(internal);
+DROP AGGREGATE IF EXISTS MAX (bigistore);
+CREATE AGGREGATE MAX(bigistore) (
+    sfunc = istore_val_larger,
+    stype = bigistore
+);
+
 ----
-DROP FUNCTION IF EXISTS istore_sum_transfn(internal, istore);
+DROP FUNCTION istore_sum_transfn(internal, istore);
+
+----
+DROP FUNCTION istore_max_transfn(internal, bigistore);
+
+----
+DROP FUNCTION istore_min_transfn(internal, bigistore);
+
+----
+DROP FUNCTION istore_max_transfn(internal, istore);
+
+----
+DROP FUNCTION istore_min_transfn(internal, istore);
+
+----
+DROP FUNCTION istore_agg_finalfn_pairs(internal);

--- a/istore--0.1.2.sql
+++ b/istore--0.1.2.sql
@@ -56,7 +56,7 @@ CREATE TYPE bigistore (
     SEND    = bigistore_send,
     STORAGE = EXTENDED
 );
- 
+
 --source file sql/istore.sql
 
 CREATE FUNCTION exist(istore, integer)
@@ -196,9 +196,19 @@ CREATE FUNCTION istore_sum_transfn(internal, istore)
     AS 'istore' ,'istore_sum_transfn'
     LANGUAGE C IMMUTABLE;
 
-CREATE FUNCTION istore_sum_finalfn(internal)
-    RETURNS bigistore
-    AS 'istore' ,'istore_sum_finalfn'
+CREATE FUNCTION istore_min_transfn(internal, istore)
+    RETURNS internal
+    AS 'istore'
+    LANGUAGE C IMMUTABLE;
+
+CREATE FUNCTION istore_max_transfn(internal, istore)
+    RETURNS internal
+    AS 'istore'
+    LANGUAGE C IMMUTABLE;
+
+CREATE FUNCTION istore_agg_finalfn_pairs(internal)
+    RETURNS istore
+    AS 'istore' ,'istore_agg_finalfn_pairs'
     LANGUAGE C IMMUTABLE STRICT;
 
 CREATE FUNCTION istore_to_json(istore)
@@ -206,21 +216,30 @@ RETURNS json
 AS 'istore', 'istore_to_json'
 LANGUAGE C IMMUTABLE STRICT;
 
+CREATE FUNCTION bigistore_agg_finalfn(internal)
+    RETURNS bigistore
+    AS 'istore' ,'bigistore_agg_finalfn_pairs'
+    LANGUAGE C IMMUTABLE STRICT;
+
 CREATE AGGREGATE SUM (
     sfunc = istore_sum_transfn,
     basetype = istore,
     stype = internal,
-    finalfunc = istore_sum_finalfn
+    finalfunc = bigistore_agg_finalfn
 );
 
-CREATE AGGREGATE MIN(istore) (
-    sfunc = istore_val_smaller,
-    stype = istore
+CREATE AGGREGATE MIN (
+    sfunc = istore_min_transfn,
+    basetype = istore,
+    stype = internal,
+    finalfunc = istore_agg_finalfn_pairs
 );
 
-CREATE AGGREGATE MAX(istore) (
-    sfunc = istore_val_larger,
-    stype = istore
+CREATE AGGREGATE MAX (
+    sfunc = istore_max_transfn,
+    basetype = istore,
+    stype = internal,
+    finalfunc = istore_agg_finalfn_pairs
 );
 
 CREATE OPERATOR -> (
@@ -308,7 +327,7 @@ AS
     FUNCTION 3 gin_extract_istore_key_query(internal, internal, int2, internal, internal),
     FUNCTION 4 gin_consistent_istore_key(internal, int2, internal, int4, internal, internal),
     STORAGE  integer;
- 
+
 --source file sql/casts.sql
 
 CREATE FUNCTION istore(bigistore)
@@ -323,7 +342,7 @@ CREATE FUNCTION bigistore(istore)
 
 CREATE CAST (istore as bigistore) WITH FUNCTION bigistore(istore) AS IMPLICIT;
 CREATE CAST (bigistore as istore) WITH FUNCTION istore(bigistore) AS ASSIGNMENT;
- 
+
 --source file sql/bigistore.sql
 
 CREATE FUNCTION exist(bigistore, integer)
@@ -478,21 +497,35 @@ CREATE FUNCTION istore_sum_transfn(internal, bigistore)
     AS 'istore' ,'bigistore_sum_transfn'
     LANGUAGE C IMMUTABLE;
 
+CREATE FUNCTION istore_min_transfn(internal, bigistore)
+    RETURNS internal
+    AS 'istore' ,'bigistore_min_transfn'
+    LANGUAGE C IMMUTABLE;
+
+CREATE FUNCTION istore_max_transfn(internal, bigistore)
+    RETURNS internal
+    AS 'istore' ,'bigistore_max_transfn'
+    LANGUAGE C IMMUTABLE;
+
 CREATE AGGREGATE SUM (
     sfunc = istore_sum_transfn,
     basetype = bigistore,
     stype = internal,
-    finalfunc = istore_sum_finalfn
+    finalfunc = bigistore_agg_finalfn
 );
 
-CREATE AGGREGATE MIN(bigistore) (
-    sfunc = istore_val_smaller,
-    stype = bigistore
+CREATE AGGREGATE MIN (
+    sfunc = istore_min_transfn,
+    basetype = bigistore,
+    stype = internal,
+    finalfunc = bigistore_agg_finalfn
 );
 
-CREATE AGGREGATE MAX(bigistore) (
-    sfunc = istore_val_larger,
-    stype = bigistore
+CREATE AGGREGATE MAX (
+    sfunc = istore_max_transfn,
+    basetype = bigistore,
+    stype = internal,
+    finalfunc = bigistore_agg_finalfn
 );
 
 CREATE OPERATOR -> (
@@ -569,4 +602,4 @@ AS
     FUNCTION 3 gin_extract_istore_key_query(internal, internal, int2, internal, internal),
     FUNCTION 4 gin_consistent_istore_key(internal, int2, internal, int4, internal, internal),
     STORAGE  integer;
- 
+

--- a/sql/bigistore.sql
+++ b/sql/bigistore.sql
@@ -152,21 +152,35 @@ CREATE FUNCTION istore_sum_transfn(internal, bigistore)
     AS 'istore' ,'bigistore_sum_transfn'
     LANGUAGE C IMMUTABLE;
 
+CREATE FUNCTION istore_min_transfn(internal, bigistore)
+    RETURNS internal
+    AS 'istore' ,'bigistore_min_transfn'
+    LANGUAGE C IMMUTABLE;
+
+CREATE FUNCTION istore_max_transfn(internal, bigistore)
+    RETURNS internal
+    AS 'istore' ,'bigistore_max_transfn'
+    LANGUAGE C IMMUTABLE;
+
 CREATE AGGREGATE SUM (
     sfunc = istore_sum_transfn,
     basetype = bigistore,
     stype = internal,
-    finalfunc = istore_sum_finalfn
+    finalfunc = bigistore_agg_finalfn
 );
 
-CREATE AGGREGATE MIN(bigistore) (
-    sfunc = istore_val_smaller,
-    stype = bigistore
+CREATE AGGREGATE MIN (
+    sfunc = istore_min_transfn,
+    basetype = bigistore,
+    stype = internal,
+    finalfunc = bigistore_agg_finalfn
 );
 
-CREATE AGGREGATE MAX(bigistore) (
-    sfunc = istore_val_larger,
-    stype = bigistore
+CREATE AGGREGATE MAX (
+    sfunc = istore_max_transfn,
+    basetype = bigistore,
+    stype = internal,
+    finalfunc = bigistore_agg_finalfn
 );
 
 CREATE OPERATOR -> (

--- a/sql/istore.sql
+++ b/sql/istore.sql
@@ -137,9 +137,19 @@ CREATE FUNCTION istore_sum_transfn(internal, istore)
     AS 'istore' ,'istore_sum_transfn'
     LANGUAGE C IMMUTABLE;
 
-CREATE FUNCTION istore_sum_finalfn(internal)
-    RETURNS bigistore
-    AS 'istore' ,'istore_sum_finalfn'
+CREATE FUNCTION istore_min_transfn(internal, istore)
+    RETURNS internal
+    AS 'istore'
+    LANGUAGE C IMMUTABLE;
+
+CREATE FUNCTION istore_max_transfn(internal, istore)
+    RETURNS internal
+    AS 'istore'
+    LANGUAGE C IMMUTABLE;
+
+CREATE FUNCTION istore_agg_finalfn_pairs(internal)
+    RETURNS istore
+    AS 'istore' ,'istore_agg_finalfn_pairs'
     LANGUAGE C IMMUTABLE STRICT;
 
 CREATE FUNCTION istore_to_json(istore)
@@ -147,21 +157,30 @@ RETURNS json
 AS 'istore', 'istore_to_json'
 LANGUAGE C IMMUTABLE STRICT;
 
+CREATE FUNCTION bigistore_agg_finalfn(internal)
+    RETURNS bigistore
+    AS 'istore' ,'bigistore_agg_finalfn_pairs'
+    LANGUAGE C IMMUTABLE STRICT;
+
 CREATE AGGREGATE SUM (
     sfunc = istore_sum_transfn,
     basetype = istore,
     stype = internal,
-    finalfunc = istore_sum_finalfn
+    finalfunc = bigistore_agg_finalfn
 );
 
-CREATE AGGREGATE MIN(istore) (
-    sfunc = istore_val_smaller,
-    stype = istore
+CREATE AGGREGATE MIN (
+    sfunc = istore_min_transfn,
+    basetype = istore,
+    stype = internal,
+    finalfunc = istore_agg_finalfn_pairs
 );
 
-CREATE AGGREGATE MAX(istore) (
-    sfunc = istore_val_larger,
-    stype = istore
+CREATE AGGREGATE MAX (
+    sfunc = istore_max_transfn,
+    basetype = istore,
+    stype = internal,
+    finalfunc = istore_agg_finalfn_pairs
 );
 
 CREATE OPERATOR -> (

--- a/src/istore.h
+++ b/src/istore.h
@@ -125,6 +125,7 @@ IStore* istore_apply_datum(IStore *arg1, Datum arg2, PGFunction applyfunc);
 BigIStore* bigistore_merge(BigIStore *arg1, BigIStore *arg2, PGFunction mergefunc, PGFunction miss1func);
 BigIStore* bigistore_apply_datum(BigIStore *arg1, Datum arg2, PGFunction applyfunc);
 
+void istore_copy_and_add_buflen(IStore *istore, BigIStorePair *pairs);
 void bigistore_add_buflen(BigIStore *istore);
 void istore_pairs_init(IStorePairs *pairs, size_t initial_size);
 void istore_pairs_insert(IStorePairs *pairs, int32 key, int32 val);

--- a/src/istore_agg.c
+++ b/src/istore_agg.c
@@ -6,29 +6,19 @@
 #define BIG_ISTORE 1
 #define ISTORE 0
 
-#define RETURN_AGG_TRANSFN(_istore, _agg)                                                        \
+#define INIT_AGG_STATE(_state)                                                                 \
     do {                                                                                         \
         MemoryContext  agg_context;                                                              \
-        ISAggState    *state;                                                                    \
                                                                                                  \
         if (!AggCheckCallContext(fcinfo, &agg_context))                                          \
             elog(ERROR, "aggregate function called in non-aggregate context");                   \
                                                                                                  \
         if (PG_ARGISNULL(1) && PG_ARGISNULL(0)) PG_RETURN_NULL();                                \
                                                                                                  \
-        state = PG_ARGISNULL(0) ? state_init(agg_context) : (ISAggState *) PG_GETARG_POINTER(0); \
+        _state = PG_ARGISNULL(0) ? state_init(agg_context) : (ISAggState *) PG_GETARG_POINTER(0);\
                                                                                                  \
-        if (PG_ARGISNULL(1)) PG_RETURN_POINTER(state);                                           \
+        if (PG_ARGISNULL(1)) PG_RETURN_POINTER(_state);                                          \
                                                                                                  \
-        switch (_istore)                                                                         \
-        {                                                                                        \
-            case BIG_ISTORE:                                                                     \
-                PG_RETURN_POINTER(bigistore_agg_internal(state, PG_GETARG_BIGIS(1), _agg));      \
-            case ISTORE:                                                                         \
-                PG_RETURN_POINTER(istore_agg_internal(state, PG_GETARG_IS(1), _agg));            \
-            default:                                                                             \
-                elog(ERROR, "unexpected istore type passed.");                                   \
-        }                                                                                        \
     } while(0)
 
 typedef struct {
@@ -273,7 +263,10 @@ PG_FUNCTION_INFO_V1(istore_min_transfn);
 Datum
 istore_min_transfn(PG_FUNCTION_ARGS)
 {
-    RETURN_AGG_TRANSFN(ISTORE, AGG_MIN);
+    ISAggState    *state;
+    INIT_AGG_STATE(state);
+
+    PG_RETURN_POINTER(istore_agg_internal(state, PG_GETARG_IS(1), AGG_MIN));
 }
 
 /*
@@ -283,7 +276,9 @@ PG_FUNCTION_INFO_V1(bigistore_min_transfn);
 Datum
 bigistore_min_transfn(PG_FUNCTION_ARGS)
 {
-    RETURN_AGG_TRANSFN(BIG_ISTORE, AGG_MIN);
+    ISAggState    *state;
+    INIT_AGG_STATE(state);
+    PG_RETURN_POINTER(bigistore_agg_internal(state, PG_GETARG_BIGIS(1), AGG_MIN));
 }
 
 /*
@@ -293,7 +288,10 @@ PG_FUNCTION_INFO_V1(istore_max_transfn);
 Datum
 istore_max_transfn(PG_FUNCTION_ARGS)
 {
-    RETURN_AGG_TRANSFN(ISTORE, AGG_MAX);
+    ISAggState    *state;
+    INIT_AGG_STATE(state);
+    PG_RETURN_POINTER(istore_agg_internal(state, PG_GETARG_IS(1), AGG_MAX));
+
 }
 
 /*
@@ -303,7 +301,10 @@ PG_FUNCTION_INFO_V1(bigistore_max_transfn);
 Datum
 bigistore_max_transfn(PG_FUNCTION_ARGS)
 {
-    RETURN_AGG_TRANSFN(BIG_ISTORE, AGG_MAX);
+    ISAggState    *state;
+    INIT_AGG_STATE(state);
+    PG_RETURN_POINTER(bigistore_agg_internal(state, PG_GETARG_BIGIS(1), AGG_MAX));
+
 }
 
 /*
@@ -313,7 +314,10 @@ PG_FUNCTION_INFO_V1(istore_sum_transfn);
 Datum
 istore_sum_transfn(PG_FUNCTION_ARGS)
 {
-    RETURN_AGG_TRANSFN(ISTORE, AGG_SUM);
+    ISAggState    *state;
+    INIT_AGG_STATE(state);
+    PG_RETURN_POINTER(istore_agg_internal(state, PG_GETARG_IS(1), AGG_SUM));
+
 }
 
 /*
@@ -323,7 +327,10 @@ PG_FUNCTION_INFO_V1(bigistore_sum_transfn);
 Datum
 bigistore_sum_transfn(PG_FUNCTION_ARGS)
 {
-    RETURN_AGG_TRANSFN(BIG_ISTORE, AGG_SUM);
+    ISAggState    *state;
+    INIT_AGG_STATE(state);
+    PG_RETURN_POINTER(bigistore_agg_internal(state, PG_GETARG_BIGIS(1), AGG_SUM));
+
 }
 
 /*

--- a/src/istore_agg.c
+++ b/src/istore_agg.c
@@ -3,52 +3,38 @@
 #define SAMESIGN(a,b)   (((a) < 0) == ((b) < 0))
 #define INITSTATESIZE 30
 
-typedef struct{
-    size_t  size;
-    int     used;
+typedef struct {
+    size_t size;
+    int    used;
     BigIStorePair pairs[0];
 } ISAggState;
+
+typedef enum {
+    AGG_SUM,
+    AGG_MIN,
+    AGG_MAX
+} AggType;
 
 static inline ISAggState *
 state_init(MemoryContext agg_context)
 {
-    ISAggState    *state;
-    state =  (ISAggState *) MemoryContextAllocZero(agg_context, sizeof(ISAggState) + INITSTATESIZE * sizeof(BigIStorePair));
+    ISAggState *state;
+    state = (ISAggState *) MemoryContextAllocZero(agg_context, sizeof(ISAggState) + INITSTATESIZE * sizeof(BigIStorePair));
     state->size = INITSTATESIZE ;
     return state;
 }
 
-/*
- * SUM(istore) aggregate funtion
- */
-PG_FUNCTION_INFO_V1(istore_sum_transfn);
-Datum
-istore_sum_transfn(PG_FUNCTION_ARGS)
+// Aggregate internal function for istore.
+static inline ISAggState *
+istore_agg_internal(ISAggState *state, IStore *istore, AggType type)
 {
-
-    MemoryContext  agg_context;
-    ISAggState    *state;
-    IStore        *istore;
-    IStorePair    *pairs2;
     BigIStorePair *pairs1;
+    IStorePair    *pairs2;
     int            index1 = 0,
                    index2 = 0;
 
-
-    if (!AggCheckCallContext(fcinfo, &agg_context))
-        elog(ERROR, "aggregate function called in non-aggregate context");
-
-    if (PG_ARGISNULL(1) && PG_ARGISNULL(0))
-        PG_RETURN_NULL();
-
-    state       = PG_ARGISNULL(0) ? state_init(agg_context) : (ISAggState *) PG_GETARG_POINTER(0);
-
-    if PG_ARGISNULL(1)
-        PG_RETURN_POINTER(state);
-
-    istore  = PG_GETARG_IS(1);
-    pairs1  = state->pairs;
-    pairs2  = FIRST_PAIR(istore, IStorePair);
+    pairs1 = state->pairs;
+    pairs2 = FIRST_PAIR(istore, IStorePair);
     while (index1 < state->used && index2 < istore->len)
     {
         if (pairs1->key < pairs2->key)
@@ -91,21 +77,34 @@ istore_sum_transfn(PG_FUNCTION_ARGS)
         else
         {
             // identical keys add values
-            /*
-             * Overflow check.  If the inputs are of different signs then their sum
-             * cannot overflow.  If the inputs are of the same sign, their sum had
-             * better be that sign too.
-             */
-            if (SAMESIGN(pairs1->val, pairs2->val)){
-                pairs1->val += pairs2->val;
-                if(!SAMESIGN(pairs1->val, pairs2->val))
-                    ereport(ERROR,
-                            (errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
-                            errmsg("bigint out of range")));
+            if (type == AGG_SUM)
+            {
+                /*
+                * Overflow check.  If the inputs are of different signs then their sum
+                * cannot overflow.  If the inputs are of the same sign, their sum had
+                * better be that sign too.
+                */
+                if (SAMESIGN(pairs1->val, pairs2->val))
+                {
+                    pairs1->val += pairs2->val;
+                    if(!SAMESIGN(pairs1->val, pairs2->val))
+                        ereport(ERROR,
+                                (errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
+                                errmsg("bigint out of range")));
+                }
+                else
+                {
+                    pairs1->val += pairs2->val;
+                }
             }
-            else
-                pairs1->val += pairs2->val;
-
+            else if (type == AGG_MIN)
+            {
+                pairs1->val = MIN(pairs2->val, pairs1->val);
+            }
+            else if (type == AGG_MAX)
+            {
+                pairs1->val = MAX(pairs2->val, pairs1->val);
+            }
 
             ++index1;
             ++index2;
@@ -135,40 +134,19 @@ istore_sum_transfn(PG_FUNCTION_ARGS)
         }
     }
 
-    PG_RETURN_POINTER(state);
+    return state;
 }
 
-/*
- * SUM(bigistore) aggregate funtion
- */
-PG_FUNCTION_INFO_V1(bigistore_sum_transfn);
-Datum
-bigistore_sum_transfn(PG_FUNCTION_ARGS)
+static inline ISAggState *
+bigistore_agg_internal(ISAggState *state, BigIStore *istore, AggType type)
 {
-
-    MemoryContext  agg_context;
-    ISAggState    *state;
-    BigIStore     *istore;
-    BigIStorePair *pairs1,
-                  *pairs2;
+    BigIStorePair *pairs2;
+    BigIStorePair *pairs1;
     int            index1 = 0,
                    index2 = 0;
 
-
-    if (!AggCheckCallContext(fcinfo, &agg_context))
-        elog(ERROR, "aggregate function called in non-aggregate context");
-
-    if (PG_ARGISNULL(1) && PG_ARGISNULL(0))
-        PG_RETURN_NULL();
-
-    state       = PG_ARGISNULL(0) ? state_init(agg_context) : (ISAggState *) PG_GETARG_POINTER(0);
-
-    if PG_ARGISNULL(1)
-        PG_RETURN_POINTER(state);
-
-    istore  = PG_GETARG_BIGIS(1);
-    pairs1  = state->pairs;
-    pairs2  = FIRST_PAIR(istore, BigIStorePair);
+    pairs1 = state->pairs;
+    pairs2 = FIRST_PAIR(istore, BigIStorePair);
     while (index1 < state->used && index2 < istore->len)
     {
         if (pairs1->key < pairs2->key)
@@ -197,30 +175,44 @@ bigistore_sum_transfn(PG_FUNCTION_ARGS)
 
             // copy data
             state->used += i;
-            memcpy(pairs1,pairs2, i * sizeof(BigIStorePair) );
+            memcpy(pairs1, pairs2, i * sizeof(BigIStorePair));
             pairs1 += i;
             pairs2 += i;
-            index1+=i;
-            index2+=i;
+            index1 += i;
+            index2 += i;
 
         }
         else
         {
-            // identical keys add values
-            /*
-             * Overflow check.  If the inputs are of different signs then their sum
-             * cannot overflow.  If the inputs are of the same sign, their sum had
-             * better be that sign too.
-             */
-            if (SAMESIGN(pairs1->val, pairs2->val)){
-                pairs1->val += pairs2->val;
-                if(!SAMESIGN(pairs1->val, pairs2->val))
-                    ereport(ERROR,
-                            (errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
-                            errmsg("bigint out of range")));
+            // identical keys - apply logic according to aggregation type
+            if (type == AGG_SUM)
+            {
+                    /*
+                    * Overflow check.  If the inputs are of different signs then their sum
+                    * cannot overflow.  If the inputs are of the same sign, their sum had
+                    * better be that sign too.
+                    */
+                    if (SAMESIGN(pairs1->val, pairs2->val))
+                    {
+                        pairs1->val += pairs2->val;
+                        if(!SAMESIGN(pairs1->val, pairs2->val))
+                            ereport(ERROR,
+                                    (errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
+                                    errmsg("bigint out of range")));
+                    }
+                    else
+                    {
+                        pairs1->val += pairs2->val;
+                    }
             }
-            else
-                pairs1->val += pairs2->val;
+            else if (type == AGG_MIN)
+            {
+                pairs1->val = MIN(pairs2->val, pairs1->val);
+            }
+            else if (type == AGG_MAX)
+            {
+                pairs1->val = MAX(pairs2->val, pairs1->val);
+            }
 
             ++index1;
             ++index2;
@@ -240,28 +232,157 @@ bigistore_sum_transfn(PG_FUNCTION_ARGS)
             pairs1      = state->pairs+index1;
         }
         state->used += i;
-        memcpy(pairs1,pairs2, i * sizeof(BigIStorePair) );
+        memcpy(pairs1,pairs2, i * sizeof(BigIStorePair));
     }
 
-    PG_RETURN_POINTER(state);
+    return state;
 }
 
+/*
+ * MIN(istore) aggregate funtion
+ */
+PG_FUNCTION_INFO_V1(istore_min_transfn);
+Datum
+istore_min_transfn(PG_FUNCTION_ARGS)
+{
+    MemoryContext  agg_context;
+    ISAggState    *state;
+
+    if (!AggCheckCallContext(fcinfo, &agg_context))
+        elog(ERROR, "aggregate function called in non-aggregate context");
+
+    if (PG_ARGISNULL(1) && PG_ARGISNULL(0)) PG_RETURN_NULL();
+
+    state = PG_ARGISNULL(0) ? state_init(agg_context) : (ISAggState *) PG_GETARG_POINTER(0);
+
+    if (PG_ARGISNULL(1)) PG_RETURN_POINTER(state);
+
+    PG_RETURN_POINTER(istore_agg_internal(state, PG_GETARG_IS(1), AGG_MIN));
+}
 
 /*
- * Final function for SUM(istore/bigistore)
- * Both transition function return the same transition type
- * and both Aggregates return bigistore so only one finalfunction
- * is needed here.
+ * MIN(bigistore) aggregate funtion
  */
-PG_FUNCTION_INFO_V1(istore_sum_finalfn);
+PG_FUNCTION_INFO_V1(bigistore_min_transfn);
 Datum
-istore_sum_finalfn(PG_FUNCTION_ARGS)
+bigistore_min_transfn(PG_FUNCTION_ARGS)
+{
+    MemoryContext  agg_context;
+    ISAggState    *state;
+
+    if (!AggCheckCallContext(fcinfo, &agg_context))
+        elog(ERROR, "aggregate function called in non-aggregate context");
+
+    if (PG_ARGISNULL(1) && PG_ARGISNULL(0)) PG_RETURN_NULL();
+
+    state = PG_ARGISNULL(0) ? state_init(agg_context) : (ISAggState *) PG_GETARG_POINTER(0);
+
+    if (PG_ARGISNULL(1)) PG_RETURN_POINTER(state);
+
+    PG_RETURN_POINTER(bigistore_agg_internal(state, PG_GETARG_BIGIS(1), AGG_MIN));
+}
+
+/*
+ * MAX(istore) aggregate funtion
+ */
+PG_FUNCTION_INFO_V1(istore_max_transfn);
+Datum
+istore_max_transfn(PG_FUNCTION_ARGS)
+{
+    MemoryContext  agg_context;
+    ISAggState    *state;
+
+    if (!AggCheckCallContext(fcinfo, &agg_context))
+        elog(ERROR, "aggregate function called in non-aggregate context");
+
+    if (PG_ARGISNULL(1) && PG_ARGISNULL(0)) PG_RETURN_NULL();
+
+    state = PG_ARGISNULL(0) ? state_init(agg_context) : (ISAggState *) PG_GETARG_POINTER(0);
+
+    if (PG_ARGISNULL(1)) PG_RETURN_POINTER(state);
+
+    PG_RETURN_POINTER(istore_agg_internal(state, PG_GETARG_IS(1), AGG_MAX));
+}
+
+/*
+ * MAX(bigistore) aggregate funtion
+ */
+PG_FUNCTION_INFO_V1(bigistore_max_transfn);
+Datum
+bigistore_max_transfn(PG_FUNCTION_ARGS)
+{
+    MemoryContext  agg_context;
+    ISAggState    *state;
+
+    if (!AggCheckCallContext(fcinfo, &agg_context))
+        elog(ERROR, "aggregate function called in non-aggregate context");
+
+    if (PG_ARGISNULL(1) && PG_ARGISNULL(0)) PG_RETURN_NULL();
+
+    state = PG_ARGISNULL(0) ? state_init(agg_context) : (ISAggState *) PG_GETARG_POINTER(0);
+
+    if (PG_ARGISNULL(1)) PG_RETURN_POINTER(state);
+
+    PG_RETURN_POINTER(bigistore_agg_internal(state, PG_GETARG_BIGIS(1), AGG_MAX));
+}
+
+/*
+ * SUM(istore) aggregate funtion
+ */
+PG_FUNCTION_INFO_V1(istore_sum_transfn);
+Datum
+istore_sum_transfn(PG_FUNCTION_ARGS)
+{
+    MemoryContext  agg_context;
+    ISAggState    *state;
+
+    if (!AggCheckCallContext(fcinfo, &agg_context))
+        elog(ERROR, "aggregate function called in non-aggregate context");
+
+    if (PG_ARGISNULL(1) && PG_ARGISNULL(0)) PG_RETURN_NULL();
+
+    state = PG_ARGISNULL(0) ? state_init(agg_context) : (ISAggState *) PG_GETARG_POINTER(0);
+
+    if (PG_ARGISNULL(1)) PG_RETURN_POINTER(state);
+
+    PG_RETURN_POINTER(istore_agg_internal(state, PG_GETARG_IS(1), AGG_SUM));
+}
+
+/*
+ * SUM(bigistore) aggregate funtion
+ */
+PG_FUNCTION_INFO_V1(bigistore_sum_transfn);
+Datum
+bigistore_sum_transfn(PG_FUNCTION_ARGS)
+{
+    MemoryContext  agg_context;
+    ISAggState *state;
+
+    if (!AggCheckCallContext(fcinfo, &agg_context))
+        elog(ERROR, "aggregate function called in non-aggregate context");
+
+    if (PG_ARGISNULL(1) && PG_ARGISNULL(0)) PG_RETURN_NULL();
+
+    state = PG_ARGISNULL(0) ? state_init(agg_context) : (ISAggState *) PG_GETARG_POINTER(0);
+
+    if (PG_ARGISNULL(1)) PG_RETURN_POINTER(state);
+
+    PG_RETURN_POINTER(bigistore_agg_internal(state, PG_GETARG_BIGIS(1), AGG_SUM));
+}
+
+/*
+ * Final function for SUM(istore/bigistore) and MIN/MAX(bigistore)
+ * Both SUM transition functions return the same transition type - the same as
+ * MIN/MAX(bigistore).
+ */
+PG_FUNCTION_INFO_V1(bigistore_agg_finalfn_pairs);
+Datum
+bigistore_agg_finalfn_pairs(PG_FUNCTION_ARGS)
 {
     ISAggState  *state;
     BigIStore   *istore;
 
-    if( PG_ARGISNULL(0))
-        PG_RETURN_NULL();
+    if (PG_ARGISNULL(0)) PG_RETURN_NULL();
 
     state       = (ISAggState *) PG_GETARG_POINTER(0);
     istore      = (BigIStore *)(palloc0(ISHDRSZ + state->used * sizeof(BigIStorePair)));
@@ -271,6 +392,29 @@ istore_sum_finalfn(PG_FUNCTION_ARGS)
     bigistore_add_buflen(istore);
 
     SET_VARSIZE(istore, ISHDRSZ + state->used * sizeof(BigIStorePair));
+
+    PG_RETURN_POINTER(istore);
+}
+
+/*
+ * Final function for MIN/MAX(istore)
+ */
+PG_FUNCTION_INFO_V1(istore_agg_finalfn_pairs);
+Datum
+istore_agg_finalfn_pairs(PG_FUNCTION_ARGS)
+{
+    ISAggState *state;
+    IStore     *istore;
+
+    if (PG_ARGISNULL(0)) PG_RETURN_NULL();
+
+    state       = (ISAggState *) PG_GETARG_POINTER(0);
+    istore      = (IStore *)(palloc0(ISHDRSZ + state->used * sizeof(IStorePair)));
+    istore->len = state->used;
+
+    istore_copy_and_add_buflen(istore, state->pairs);
+
+    SET_VARSIZE(istore, ISHDRSZ + state->used * sizeof(IStorePair));
 
     PG_RETURN_POINTER(istore);
 }

--- a/src/istore_agg.c
+++ b/src/istore_agg.c
@@ -3,6 +3,19 @@
 #define SAMESIGN(a,b)   (((a) < 0) == ((b) < 0))
 #define INITSTATESIZE 30
 
+#define AGG_TRANSFN_INIT                                                                     \
+    MemoryContext  agg_context;                                                              \
+    ISAggState    *state;                                                                    \
+                                                                                             \
+    if (!AggCheckCallContext(fcinfo, &agg_context))                                          \
+        elog(ERROR, "aggregate function called in non-aggregate context");                   \
+                                                                                             \
+    if (PG_ARGISNULL(1) && PG_ARGISNULL(0)) PG_RETURN_NULL();                                \
+                                                                                             \
+    state = PG_ARGISNULL(0) ? state_init(agg_context) : (ISAggState *) PG_GETARG_POINTER(0); \
+                                                                                             \
+    if (PG_ARGISNULL(1)) PG_RETURN_POINTER(state);                                           \
+
 typedef struct {
     size_t size;
     int    used;
@@ -245,17 +258,7 @@ PG_FUNCTION_INFO_V1(istore_min_transfn);
 Datum
 istore_min_transfn(PG_FUNCTION_ARGS)
 {
-    MemoryContext  agg_context;
-    ISAggState    *state;
-
-    if (!AggCheckCallContext(fcinfo, &agg_context))
-        elog(ERROR, "aggregate function called in non-aggregate context");
-
-    if (PG_ARGISNULL(1) && PG_ARGISNULL(0)) PG_RETURN_NULL();
-
-    state = PG_ARGISNULL(0) ? state_init(agg_context) : (ISAggState *) PG_GETARG_POINTER(0);
-
-    if (PG_ARGISNULL(1)) PG_RETURN_POINTER(state);
+    AGG_TRANSFN_INIT;
 
     PG_RETURN_POINTER(istore_agg_internal(state, PG_GETARG_IS(1), AGG_MIN));
 }
@@ -267,17 +270,7 @@ PG_FUNCTION_INFO_V1(bigistore_min_transfn);
 Datum
 bigistore_min_transfn(PG_FUNCTION_ARGS)
 {
-    MemoryContext  agg_context;
-    ISAggState    *state;
-
-    if (!AggCheckCallContext(fcinfo, &agg_context))
-        elog(ERROR, "aggregate function called in non-aggregate context");
-
-    if (PG_ARGISNULL(1) && PG_ARGISNULL(0)) PG_RETURN_NULL();
-
-    state = PG_ARGISNULL(0) ? state_init(agg_context) : (ISAggState *) PG_GETARG_POINTER(0);
-
-    if (PG_ARGISNULL(1)) PG_RETURN_POINTER(state);
+    AGG_TRANSFN_INIT;
 
     PG_RETURN_POINTER(bigistore_agg_internal(state, PG_GETARG_BIGIS(1), AGG_MIN));
 }
@@ -289,17 +282,7 @@ PG_FUNCTION_INFO_V1(istore_max_transfn);
 Datum
 istore_max_transfn(PG_FUNCTION_ARGS)
 {
-    MemoryContext  agg_context;
-    ISAggState    *state;
-
-    if (!AggCheckCallContext(fcinfo, &agg_context))
-        elog(ERROR, "aggregate function called in non-aggregate context");
-
-    if (PG_ARGISNULL(1) && PG_ARGISNULL(0)) PG_RETURN_NULL();
-
-    state = PG_ARGISNULL(0) ? state_init(agg_context) : (ISAggState *) PG_GETARG_POINTER(0);
-
-    if (PG_ARGISNULL(1)) PG_RETURN_POINTER(state);
+    AGG_TRANSFN_INIT;
 
     PG_RETURN_POINTER(istore_agg_internal(state, PG_GETARG_IS(1), AGG_MAX));
 }
@@ -311,17 +294,7 @@ PG_FUNCTION_INFO_V1(bigistore_max_transfn);
 Datum
 bigistore_max_transfn(PG_FUNCTION_ARGS)
 {
-    MemoryContext  agg_context;
-    ISAggState    *state;
-
-    if (!AggCheckCallContext(fcinfo, &agg_context))
-        elog(ERROR, "aggregate function called in non-aggregate context");
-
-    if (PG_ARGISNULL(1) && PG_ARGISNULL(0)) PG_RETURN_NULL();
-
-    state = PG_ARGISNULL(0) ? state_init(agg_context) : (ISAggState *) PG_GETARG_POINTER(0);
-
-    if (PG_ARGISNULL(1)) PG_RETURN_POINTER(state);
+    AGG_TRANSFN_INIT;
 
     PG_RETURN_POINTER(bigistore_agg_internal(state, PG_GETARG_BIGIS(1), AGG_MAX));
 }
@@ -333,17 +306,7 @@ PG_FUNCTION_INFO_V1(istore_sum_transfn);
 Datum
 istore_sum_transfn(PG_FUNCTION_ARGS)
 {
-    MemoryContext  agg_context;
-    ISAggState    *state;
-
-    if (!AggCheckCallContext(fcinfo, &agg_context))
-        elog(ERROR, "aggregate function called in non-aggregate context");
-
-    if (PG_ARGISNULL(1) && PG_ARGISNULL(0)) PG_RETURN_NULL();
-
-    state = PG_ARGISNULL(0) ? state_init(agg_context) : (ISAggState *) PG_GETARG_POINTER(0);
-
-    if (PG_ARGISNULL(1)) PG_RETURN_POINTER(state);
+    AGG_TRANSFN_INIT;
 
     PG_RETURN_POINTER(istore_agg_internal(state, PG_GETARG_IS(1), AGG_SUM));
 }
@@ -355,17 +318,7 @@ PG_FUNCTION_INFO_V1(bigistore_sum_transfn);
 Datum
 bigistore_sum_transfn(PG_FUNCTION_ARGS)
 {
-    MemoryContext  agg_context;
-    ISAggState *state;
-
-    if (!AggCheckCallContext(fcinfo, &agg_context))
-        elog(ERROR, "aggregate function called in non-aggregate context");
-
-    if (PG_ARGISNULL(1) && PG_ARGISNULL(0)) PG_RETURN_NULL();
-
-    state = PG_ARGISNULL(0) ? state_init(agg_context) : (ISAggState *) PG_GETARG_POINTER(0);
-
-    if (PG_ARGISNULL(1)) PG_RETURN_POINTER(state);
+    AGG_TRANSFN_INIT;
 
     PG_RETURN_POINTER(bigistore_agg_internal(state, PG_GETARG_BIGIS(1), AGG_SUM));
 }

--- a/src/pairs.c
+++ b/src/pairs.c
@@ -5,20 +5,37 @@
 static inline int digits32(int32 num);
 static inline int digits64(int64 num);
 
-
-
 /*
- * add buflen to istore
+ * copy *src_pairs to the IStorePair of *istore and add buflen to *istore
  */
 void
-bigistore_add_buflen(BigIStore *istore) 
+istore_copy_and_add_buflen(IStore *istore, BigIStorePair *src_pairs)
+{
+    IStorePair *dest_pairs = FIRST_PAIR(istore, IStorePair);
+
+    for (int i = 0; i < istore->len; ++i)
+    {
+        dest_pairs[i].key = src_pairs[i].key;
+        dest_pairs[i].val = src_pairs[i].val;
+        istore->buflen += digits32(dest_pairs[i].key) + digits32(dest_pairs[i].val) + BUFLEN_OFFSET;
+    }
+
+    if (istore->buflen < 0)
+        elog(ERROR, "istore buffer overflow");
+}
+
+/*
+ * add buflen to bigistore
+ */
+void
+bigistore_add_buflen(BigIStore *istore)
 {
     BigIStorePair  *pairs;
 
     pairs  = FIRST_PAIR(istore, BigIStorePair);
-    
+
     for(int i = 0; i < istore->len; i++)
-        istore->buflen += digits32(pairs[i].key) + digits64(pairs[i].val) + BUFLEN_OFFSET;   
+        istore->buflen += digits32(pairs[i].key) + digits64(pairs[i].val) + BUFLEN_OFFSET;
 
     if (istore->buflen < 0)
         elog(ERROR, "istore buffer overflow");


### PR DESCRIPTION
Introduces custom transition state to MAX/MIN the same as on the SUM aggregate.

@rapimo as discussed this implements the base branch approach to MAX/MIN. I managed to reproduce the performance increase with an average `180ms` for version `0.1.1` over ~ 260K istores v.s. average of `102ms` for version `0.1.2` over the same set.

