### PR TITLE
Minor refactoring

### DIFF
--- a/src/bigistore.c
+++ b/src/bigistore.c
@@ -17,7 +17,7 @@ static inline Datum *bigistore_key_val_datums(BigIStore *is);
  * change.
  * if PGFunction miss1func is NULL the result will only contain matching keys
  */
-BigIStore *
+static BigIStore *
 bigistore_merge(BigIStore *arg1, BigIStore *arg2, PGFunction mergefunc, PGFunction miss1func)
 {
     BigIStore *     result;
@@ -80,7 +80,7 @@ bigistore_merge(BigIStore *arg1, BigIStore *arg2, PGFunction mergefunc, PGFuncti
 /*
  * apply PGFunction applyfunc on each value of arg1 with arg2
  */
-BigIStore *
+static BigIStore *
 bigistore_apply_datum(BigIStore *arg1, Datum arg2, PGFunction applyfunc)
 {
     BigIStore *     result;
@@ -211,7 +211,7 @@ Datum bigistore_sum_up(PG_FUNCTION_ARGS)
 /*
  * Binary search the key in the bigistore.
  */
-BigIStorePair *
+static BigIStorePair *
 bigistore_find(BigIStore *is, int32 key, int *off_out)
 {
     BigIStorePair *pairs  = FIRST_PAIR(is, BigIStorePair);
@@ -1099,7 +1099,8 @@ Datum bigistore_slice_to_array(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(aout);
 }
 
-static BigIStore * bigistore_clamp_pass(BigIStore * is, int32 clamp_key, int delta_dir)
+static BigIStore *
+bigistore_clamp_pass(BigIStore * is, int32 clamp_key, int delta_dir)
 {
     BigIStore     * result_is;
     BigIStorePair * pairs;

--- a/src/depcode.c
+++ b/src/depcode.c
@@ -8,8 +8,8 @@
  */
 
 
-Datum istore_array_sum(Datum *data, int count, bool *nulls);
-Datum bigistore_array_sum(Datum *data, int count, bool *nulls);
+static Datum istore_array_sum(Datum *data, int count, bool *nulls);
+static Datum bigistore_array_sum(Datum *data, int count, bool *nulls);
 
 /*
  * sum aggregation final function
@@ -80,7 +80,7 @@ istore_agg_finalfn(PG_FUNCTION_ARGS)
 /*
  * summarize an array of istores
  */
-Datum
+static Datum
 istore_array_sum(Datum *data, int count, bool *nulls)
 {
     BigIStore       *out;
@@ -132,7 +132,7 @@ istore_array_sum(Datum *data, int count, bool *nulls)
 /*
  * summarize an array of bigistores
  */
-Datum
+static Datum
 bigistore_array_sum(Datum *data, int count, bool *nulls)
 {
     BigIStore       *out;

--- a/src/istore.c
+++ b/src/istore.c
@@ -19,7 +19,7 @@ static inline Datum *istore_key_val_datums(IStore *is);
  * change.
  * if PGFunction miss1func is NULL only the result will only contain matching keys
  */
-IStore *
+static IStore *
 istore_merge(IStore *arg1, IStore *arg2, PGFunction mergefunc, PGFunction miss1func)
 {
     IStore *     result;
@@ -82,7 +82,7 @@ istore_merge(IStore *arg1, IStore *arg2, PGFunction mergefunc, PGFunction miss1f
 /*
  * apply PGFunction applyfunc on each value of arg1 with arg2
  */
-IStore *
+static IStore *
 istore_apply_datum(IStore *arg1, Datum arg2, PGFunction applyfunc)
 {
     IStore *     result;
@@ -213,7 +213,7 @@ Datum istore_sum_up(PG_FUNCTION_ARGS)
 /*
  * Binary search the key in the istore.
  */
-IStorePair *
+static IStorePair *
 istore_find(IStore *is, int32 key, int *off_out)
 {
     IStorePair *pairs  = FIRST_PAIR(is, IStorePair);

--- a/src/istore.h
+++ b/src/istore.h
@@ -130,26 +130,16 @@ typedef struct
     int32 len;
 } BigIStore;
 
-IStore *istore_merge(IStore *arg1, IStore *arg2, PGFunction mergefunc, PGFunction miss1func);
-IStore *istore_apply_datum(IStore *arg1, Datum arg2, PGFunction applyfunc);
-
-BigIStore *bigistore_merge(BigIStore *arg1, BigIStore *arg2, PGFunction mergefunc, PGFunction miss1func);
-BigIStore *bigistore_apply_datum(BigIStore *arg1, Datum arg2, PGFunction applyfunc);
-
 void           istore_copy_and_add_buflen(IStore *istore, BigIStorePair *pairs);
-void           bigistore_add_buflen(BigIStore *istore);
 void           istore_pairs_init(IStorePairs *pairs, size_t initial_size);
 void           istore_pairs_insert(IStorePairs *pairs, int32 key, int32 val);
-int            istore_pairs_cmp(const void *a, const void *b);
 void           istore_tree_to_pairs(AvlNode *p, IStorePairs *pairs);
-IStorePair *   istore_find(IStore *is, int32 key, int *off_out);
 int            is_pair_buf_len(IStorePair *pair);
-int            bigis_pair_buf_len(BigIStorePair *pair);
+void           bigistore_add_buflen(BigIStore *istore);
 void           bigistore_pairs_init(BigIStorePairs *pairs, size_t initial_size);
 void           bigistore_pairs_insert(BigIStorePairs *pairs, int32 key, int64 val);
-int            bigistore_pairs_cmp(const void *a, const void *b);
 void           bigistore_tree_to_pairs(AvlNode *p, BigIStorePairs *pairs);
-BigIStorePair *bigistore_find(BigIStore *is, int32 key, int *off_out);
+int            bigis_pair_buf_len(BigIStorePair *pair);
 
 int is_int32_arr_comp(const void *a, const void *b);
 
@@ -172,7 +162,6 @@ int is_int32_arr_comp(const void *a, const void *b);
 /*
  * get the istore
  */
-
 #define PG_GETARG_IS(x) (IStore *) PG_DETOAST_DATUM(PG_GETARG_DATUM(x))
 #define PG_GETARG_BIGIS(x) (BigIStore *) PG_DETOAST_DATUM(PG_GETARG_DATUM(x))
 #define PG_GETARG_IS_COPY(x) (IStore *) PG_DETOAST_DATUM_COPY(PG_GETARG_DATUM(x))
@@ -181,7 +170,6 @@ int is_int32_arr_comp(const void *a, const void *b);
 /*
  * creates the internal representation from a pairs collection
  */
-
 #define FINALIZE_ISTORE_BASE(_istore, _pairs, _pairtype) \
         _istore         = palloc0(ISHDRSZ + PAYLOAD_SIZE(_pairs, _pairtype));\
         _istore->buflen = _pairs->buflen;\

--- a/src/istore_agg.c
+++ b/src/istore_agg.c
@@ -95,33 +95,32 @@ istore_agg_internal(ISAggState *state, IStore *istore, ISAggType type)
         else
         {
             // identical keys add values
-            if (type == AGG_SUM)
+            switch (type)
             {
-                /*
-                * Overflow check.  If the inputs are of different signs then their sum
-                * cannot overflow.  If the inputs are of the same sign, their sum had
-                * better be that sign too.
-                */
-                if (SAMESIGN(pairs1->val, pairs2->val))
-                {
-                    pairs1->val += pairs2->val;
-                    if(!SAMESIGN(pairs1->val, pairs2->val))
-                        ereport(ERROR,
-                                (errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
-                                errmsg("bigint out of range")));
-                }
-                else
-                {
-                    pairs1->val += pairs2->val;
-                }
-            }
-            else if (type == AGG_MIN)
-            {
-                pairs1->val = MIN(pairs2->val, pairs1->val);
-            }
-            else if (type == AGG_MAX)
-            {
-                pairs1->val = MAX(pairs2->val, pairs1->val);
+                case AGG_SUM:
+                    /*
+                     * Overflow check.  If the inputs are of different signs then their sum
+                     * cannot overflow.  If the inputs are of the same sign, their sum had
+                     * better be that sign too.
+                     */
+                    if (SAMESIGN(pairs1->val, pairs2->val))
+                    {
+                        pairs1->val += pairs2->val;
+                        if(!SAMESIGN(pairs1->val, pairs2->val))
+                            ereport(ERROR,
+                                    (errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
+                                    errmsg("bigint out of range")));
+                    }
+                    else
+                    {
+                        pairs1->val += pairs2->val;
+                    }
+                    break;
+                case AGG_MIN:
+                    pairs1->val = MIN(pairs2->val, pairs1->val);
+                    break;
+                case AGG_MAX:
+                    pairs1->val = MAX(pairs2->val, pairs1->val);
             }
 
             ++index1;
@@ -203,17 +202,18 @@ bigistore_agg_internal(ISAggState *state, BigIStore *istore, ISAggType type)
         else
         {
             // identical keys - apply logic according to aggregation type
-            if (type == AGG_SUM)
+            switch (type)
             {
+                case AGG_SUM:
                     /*
-                    * Overflow check.  If the inputs are of different signs then their sum
-                    * cannot overflow.  If the inputs are of the same sign, their sum had
-                    * better be that sign too.
-                    */
+                     * Overflow check.  If the inputs are of different signs then their sum
+                     * cannot overflow.  If the inputs are of the same sign, their sum had
+                     * better be that sign too.
+                     */
                     if (SAMESIGN(pairs1->val, pairs2->val))
                     {
                         pairs1->val += pairs2->val;
-                        if(!SAMESIGN(pairs1->val, pairs2->val))
+                        if (!SAMESIGN(pairs1->val, pairs2->val))
                             ereport(ERROR,
                                     (errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
                                     errmsg("bigint out of range")));
@@ -222,14 +222,12 @@ bigistore_agg_internal(ISAggState *state, BigIStore *istore, ISAggType type)
                     {
                         pairs1->val += pairs2->val;
                     }
-            }
-            else if (type == AGG_MIN)
-            {
-                pairs1->val = MIN(pairs2->val, pairs1->val);
-            }
-            else if (type == AGG_MAX)
-            {
-                pairs1->val = MAX(pairs2->val, pairs1->val);
+                    break;
+                case AGG_MIN:
+                    pairs1->val = MIN(pairs2->val, pairs1->val);
+                    break;
+                case AGG_MAX:
+                    pairs1->val = MAX(pairs2->val, pairs1->val);
             }
 
             ++index1;


### PR DESCRIPTION
This patch:
* makes functions that are only used within its module `static`;
* removes `istore_pairs_cmp` and `bigistore_pairs_cmp` declaration as they aren't used anywhere and don't have implementation;
* replaces series of `if-else` statements with `switch` as it supposed to be slightly more efficient.