### PR TITLE
Add support for PostgreSQL 9.2

### DIFF
--- a/istore--0.1.3--0.1.4.sql
+++ b/istore--0.1.3--0.1.4.sql
@@ -23,14 +23,14 @@ CREATE OR REPLACE FUNCTION istore_avl_transfn(internal, integer, integer)
  IMMUTABLE
 AS 'istore', $function$istore_avl_transfn$function$;
 ----aggregates----
-  CREATE AGGREGATE isagg(key integer, value bigint) (
+  CREATE AGGREGATE isagg(integer, bigint) (
     SFUNC = bigistore_avl_transfn,
   STYPE = internal,
   FINALFUNC = bigistore_avl_finalfn
   );
 
 ----
-  CREATE AGGREGATE isagg(key integer, value integer) (
+  CREATE AGGREGATE isagg(integer, integer) (
     SFUNC = istore_avl_transfn,
   STYPE = internal,
   FINALFUNC = istore_avl_finalfn

--- a/istore--0.1.4--0.1.3.sql
+++ b/istore--0.1.4--0.1.3.sql
@@ -1,7 +1,7 @@
 ----aggregates----
-DROP AGGREGATE IF EXISTS isagg (key integer, value bigint);
+DROP AGGREGATE IF EXISTS isagg (integer, bigint);
 ----
-DROP AGGREGATE IF EXISTS isagg (key integer, value integer);
+DROP AGGREGATE IF EXISTS isagg (integer, integer);
 ----functions----
 DROP FUNCTION IF EXISTS bigistore_avl_finalfn(internal);
 ----

--- a/istore--0.1.4.sql
+++ b/istore--0.1.4.sql
@@ -254,7 +254,7 @@ CREATE AGGREGATE MAX (
     finalfunc = istore_agg_finalfn_pairs
 );
 
-CREATE AGGREGATE ISAGG(key int, value int) (
+CREATE AGGREGATE ISAGG(int, int) (
     sfunc = istore_avl_transfn,
     stype = internal,
     finalfunc = istore_avl_finalfn
@@ -559,7 +559,7 @@ CREATE AGGREGATE MAX (
     finalfunc = bigistore_agg_finalfn
 );
 
-CREATE AGGREGATE ISAGG(key int, value bigint) (
+CREATE AGGREGATE ISAGG(int, bigint) (
     sfunc = bigistore_avl_transfn,
     stype = internal,
     finalfunc = bigistore_avl_finalfn

--- a/istore--0.1.5.sql
+++ b/istore--0.1.5.sql
@@ -258,7 +258,7 @@ CREATE AGGREGATE MAX (
     finalfunc = istore_agg_finalfn_pairs
 );
 
-CREATE AGGREGATE ISAGG(key int, value int) (
+CREATE AGGREGATE ISAGG(int, int) (
     sfunc = istore_avl_transfn,
     stype = internal,
     finalfunc = istore_avl_finalfn
@@ -551,7 +551,7 @@ CREATE AGGREGATE MAX (
     finalfunc = bigistore_agg_finalfn
 );
 
-CREATE AGGREGATE ISAGG(key int, value bigint) (
+CREATE AGGREGATE ISAGG(int, bigint) (
     sfunc = bigistore_avl_transfn,
     stype = internal,
     finalfunc = bigistore_avl_finalfn

--- a/istore--0.1.6.sql
+++ b/istore--0.1.6.sql
@@ -321,7 +321,7 @@ CREATE AGGREGATE MAX (
     finalfunc = istore_agg_finalfn_pairs
 );
 
-CREATE AGGREGATE ISAGG(key int, value int) (
+CREATE AGGREGATE ISAGG(int, int) (
     sfunc = istore_avl_transfn,
     stype = internal,
     finalfunc = istore_avl_finalfn
@@ -708,7 +708,7 @@ CREATE AGGREGATE MAX (
     finalfunc = bigistore_agg_finalfn
 );
 
-CREATE AGGREGATE ISAGG(key int, value bigint) (
+CREATE AGGREGATE ISAGG(int, bigint) (
     sfunc = bigistore_avl_transfn,
     stype = internal,
     finalfunc = bigistore_avl_finalfn

--- a/istore--0.1.7.sql
+++ b/istore--0.1.7.sql
@@ -331,7 +331,7 @@ CREATE AGGREGATE MAX (
     finalfunc = istore_agg_finalfn_pairs
 );
 
-CREATE AGGREGATE ISAGG(key int, value int) (
+CREATE AGGREGATE ISAGG(int, int) (
     sfunc = istore_avl_transfn,
     stype = internal,
     finalfunc = istore_avl_finalfn
@@ -743,7 +743,7 @@ CREATE AGGREGATE MAX (
     finalfunc = bigistore_agg_finalfn
 );
 
-CREATE AGGREGATE ISAGG(key int, value bigint) (
+CREATE AGGREGATE ISAGG(int, bigint) (
     sfunc = bigistore_avl_transfn,
     stype = internal,
     finalfunc = bigistore_avl_finalfn

--- a/istore--0.1.8.sql
+++ b/istore--0.1.8.sql
@@ -331,7 +331,7 @@ CREATE AGGREGATE MAX (
     finalfunc = istore_agg_finalfn_pairs
 );
 
-CREATE AGGREGATE ISAGG(key int, value int) (
+CREATE AGGREGATE ISAGG(int, int) (
     sfunc = istore_avl_transfn,
     stype = internal,
     finalfunc = istore_avl_finalfn
@@ -743,7 +743,7 @@ CREATE AGGREGATE MAX (
     finalfunc = bigistore_agg_finalfn
 );
 
-CREATE AGGREGATE ISAGG(key int, value bigint) (
+CREATE AGGREGATE ISAGG(int, bigint) (
     sfunc = bigistore_avl_transfn,
     stype = internal,
     finalfunc = bigistore_avl_finalfn

--- a/sql/bigistore.sql
+++ b/sql/bigistore.sql
@@ -268,7 +268,7 @@ CREATE AGGREGATE MAX (
     finalfunc = bigistore_agg_finalfn
 );
 
-CREATE AGGREGATE ISAGG(key int, value bigint) (
+CREATE AGGREGATE ISAGG(int, bigint) (
     sfunc = bigistore_avl_transfn,
     stype = internal,
     finalfunc = bigistore_avl_finalfn

--- a/sql/istore.sql
+++ b/sql/istore.sql
@@ -272,7 +272,7 @@ CREATE AGGREGATE MAX (
     finalfunc = istore_agg_finalfn_pairs
 );
 
-CREATE AGGREGATE ISAGG(key int, value int) (
+CREATE AGGREGATE ISAGG(int, int) (
     sfunc = istore_avl_transfn,
     stype = internal,
     finalfunc = istore_avl_finalfn

--- a/src/bigistore.c
+++ b/src/bigistore.c
@@ -1,6 +1,10 @@
 #include "istore.h"
 
+#if PG_VERSION_NUM < 90300
+#include "access/htup.h"
+#else
 #include "access/htup_details.h"
+#endif
 #include "catalog/pg_type.h"
 #include "funcapi.h"
 #include "utils/array.h"

--- a/src/istore.c
+++ b/src/istore.c
@@ -1,6 +1,10 @@
 #include "istore.h"
 
+#if PG_VERSION_NUM < 90300
+#include "access/htup.h"
+#else
 #include "access/htup_details.h"
+#endif
 #include "catalog/pg_type.h"
 #include "funcapi.h"
 #include "utils/array.h"

--- a/src/istore.h
+++ b/src/istore.h
@@ -8,76 +8,24 @@
 #include "utils/builtins.h"
 #include "utils/memutils.h"
 
-Datum istore_out(PG_FUNCTION_ARGS);
-Datum istore_in(PG_FUNCTION_ARGS);
-Datum istore_recv(PG_FUNCTION_ARGS);
-Datum istore_send(PG_FUNCTION_ARGS);
-Datum istore_to_json(PG_FUNCTION_ARGS);
-Datum istore_array_add(PG_FUNCTION_ARGS);
-Datum istore_from_intarray(PG_FUNCTION_ARGS);
-Datum istore_multiply_integer(PG_FUNCTION_ARGS);
-Datum istore_multiply(PG_FUNCTION_ARGS);
-Datum istore_divide_integer(PG_FUNCTION_ARGS);
-Datum istore_divide_int8(PG_FUNCTION_ARGS);
-Datum istore_divide(PG_FUNCTION_ARGS);
-Datum istore_subtract_integer(PG_FUNCTION_ARGS);
-Datum istore_subtract(PG_FUNCTION_ARGS);
-Datum istore_add_integer(PG_FUNCTION_ARGS);
-Datum istore_add(PG_FUNCTION_ARGS);
-Datum istore_fetchval(PG_FUNCTION_ARGS);
-Datum istore_exist(PG_FUNCTION_ARGS);
-Datum istore_sum_up(PG_FUNCTION_ARGS);
-Datum istore_each(PG_FUNCTION_ARGS);
-Datum istore_fill_gaps(PG_FUNCTION_ARGS);
-Datum istore_accumulate(PG_FUNCTION_ARGS);
-Datum istore_seed(PG_FUNCTION_ARGS);
-Datum istore_val_larger(PG_FUNCTION_ARGS);
-Datum istore_val_smaller(PG_FUNCTION_ARGS);
-Datum istore_min_key(PG_FUNCTION_ARGS);
-Datum istore_max_key(PG_FUNCTION_ARGS);
-Datum istore_compact(PG_FUNCTION_ARGS);
-Datum istore_akeys(PG_FUNCTION_ARGS);
-Datum istore_avals(PG_FUNCTION_ARGS);
-Datum istore_skeys(PG_FUNCTION_ARGS);
-Datum istore_svals(PG_FUNCTION_ARGS);
-Datum istore_length(PG_FUNCTION_ARGS);
-Datum istore_sum_transfn(PG_FUNCTION_ARGS);
-Datum istore_sum_finalfn(PG_FUNCTION_ARGS);
-
-Datum bigistore_out(PG_FUNCTION_ARGS);
-Datum bigistore_in(PG_FUNCTION_ARGS);
-Datum bigistore_recv(PG_FUNCTION_ARGS);
-Datum bigistore_send(PG_FUNCTION_ARGS);
-Datum bigistore_to_json(PG_FUNCTION_ARGS);
-Datum bigistore_array_add(PG_FUNCTION_ARGS);
-Datum bigistore_from_intarray(PG_FUNCTION_ARGS);
-Datum bigistore_multiply_integer(PG_FUNCTION_ARGS);
-Datum bigistore_multiply(PG_FUNCTION_ARGS);
-Datum bigistore_divide_integer(PG_FUNCTION_ARGS);
-Datum bigistore_divide_int8(PG_FUNCTION_ARGS);
-Datum bigistore_divide(PG_FUNCTION_ARGS);
-Datum bigistore_subtract_integer(PG_FUNCTION_ARGS);
-Datum bigistore_subtract(PG_FUNCTION_ARGS);
-Datum bigistore_add_integer(PG_FUNCTION_ARGS);
-Datum bigistore_add(PG_FUNCTION_ARGS);
-Datum bigistore_fetchval(PG_FUNCTION_ARGS);
-Datum bigistore_exist(PG_FUNCTION_ARGS);
-Datum bigistore_sum_up(PG_FUNCTION_ARGS);
-Datum bigistore_each(PG_FUNCTION_ARGS);
-Datum bigistore_fill_gaps(PG_FUNCTION_ARGS);
-Datum bigistore_accumulate(PG_FUNCTION_ARGS);
-Datum bigistore_seed(PG_FUNCTION_ARGS);
-Datum bigistore_val_larger(PG_FUNCTION_ARGS);
-Datum bigistore_val_smaller(PG_FUNCTION_ARGS);
-Datum bigistore_min_key(PG_FUNCTION_ARGS);
-Datum bigistore_max_key(PG_FUNCTION_ARGS);
-Datum bigistore_compact(PG_FUNCTION_ARGS);
-Datum bigistore_akeys(PG_FUNCTION_ARGS);
-Datum bigistore_avals(PG_FUNCTION_ARGS);
-Datum bigistore_skeys(PG_FUNCTION_ARGS);
-Datum bigistore_svals(PG_FUNCTION_ARGS);
-Datum bigistore_length(PG_FUNCTION_ARGS);
-Datum bigistore_sum_transfn(PG_FUNCTION_ARGS);
+/*
+ * Until version 9.4 postgres didn't have "extern" function declaration in
+ * PG_FUNCTION_INFO_V1. This is a quick fix that allows us not to declare every
+ * function manually. Copied from the PostgreSQL 12 source code (see fmgr.h)
+ */
+#if PG_VERSION_NUM < 90400
+#undef PG_FUNCTION_INFO_V1
+#define PG_FUNCTION_INFO_V1(funcname) \
+extern Datum funcname(PG_FUNCTION_ARGS); \
+extern PGDLLEXPORT const Pg_finfo_record * CppConcat(pg_finfo_,funcname)(void); \
+const Pg_finfo_record * \
+CppConcat(pg_finfo_,funcname) (void) \
+{ \
+	static const Pg_finfo_record my_finfo = { 1 }; \
+	return &my_finfo; \
+} \
+extern int no_such_variable
+#endif
 
 /*
  * a single key/value pair

--- a/src/istore_agg.c
+++ b/src/istore_agg.c
@@ -69,8 +69,9 @@ static inline ISAggState *
 istore_agg_internal(ISAggState *state, IStore *istore, ISAggType type)
 {
     BigIStorePair *pairs1;
-    IStorePair *   pairs2;
+    IStorePair    *pairs2;
     int            index1 = 0, index2 = 0;
+    int            left;
 
     pairs1 = state->pairs;
     pairs2 = FIRST_PAIR(istore, IStorePair);
@@ -144,14 +145,14 @@ istore_agg_internal(ISAggState *state, IStore *istore, ISAggType type)
     }
 
     // append any leftovers
-    int i = istore->len - index2;
-    if (i > 0)
+    left = istore->len - index2;
+    if (left > 0)
     {
-        state = state_extend(state, i);
-        state->used += i;
+        state = state_extend(state, left);
+        state->used += left;
         pairs1 = state->pairs + index1;
         // we can't use memcpy here as pairs1 and pairs2 differ in type
-        for (int j = 0; j < i; j++)
+        for (int j = 0; j < left; j++)
         {
             pairs1->key = pairs2->key;
             pairs1->val = pairs2->val;
@@ -168,6 +169,7 @@ istore_agg_state_accum(ISAggState *state, int num_paris, BigIStorePair *pairs2, 
 {
     BigIStorePair *pairs1;
     int            index1 = 0, index2 = 0;
+    int            left;
 
     pairs1 = state->pairs;
     while (index1 < state->used && index2 < num_paris)
@@ -236,13 +238,13 @@ istore_agg_state_accum(ISAggState *state, int num_paris, BigIStorePair *pairs2, 
     }
 
     // append any leftovers
-    int i = num_paris - index2;
-    if (i > 0)
+    left = num_paris - index2;
+    if (left > 0)
     {
-        state = state_extend(state, i);
-        state->used += i;
+        state = state_extend(state, left);
+        state->used += left;
         pairs1 = state->pairs + index1;
-        memcpy(pairs1, pairs2, i * sizeof(BigIStorePair));
+        memcpy(pairs1, pairs2, left * sizeof(BigIStorePair));
     }
 
     return state;


### PR DESCRIPTION
As were mentioned in #79 `istore` doesn't work in PostgreSQL 9.2. This patch fixes that. It also fixes few warnings.