### PR TITLE
Fix integer overflow in clamp_below() and clamp_above() for BigIStore

### DIFF
--- a/src/bigistore.c
+++ b/src/bigistore.c
@@ -1250,7 +1250,7 @@ bigistore_clamp_pass(BigIStore *is, int32 clamp_key, int delta_dir)
     BigIStore *    result_is;
     BigIStorePair *pairs;
     BigIStorePairs creator;
-    int32          clamp_sum = 0;
+    int64          clamp_sum = 0;
     int            index = 0, count = 0, delta_buflen = 0;
 
     /* short circuit out of the funciton if there is nothing to clamp */

--- a/test/expected/functions_plain_test.out
+++ b/test/expected/functions_plain_test.out
@@ -1367,6 +1367,12 @@ SELECT clamp_below('-5=>1, -1=>1, 0=>1, 1=>1'::bigistore, 2);
  "2"=>"4"
 (1 row)
 
+SELECT clamp_below('1=>1, 2=>2147483647, 3=>42'::bigistore, 2);
+         clamp_below          
+------------------------------
+ "2"=>"2147483648", "3"=>"42"
+(1 row)
+
 ROLLBACK;
 BEGIN;
 -- bigistore functions clamp should clamp keys that are above a specified threshold;

--- a/test/sql/functions_plain_test.sql
+++ b/test/sql/functions_plain_test.sql
@@ -474,6 +474,7 @@ SELECT clamp_below('-2=>1, -1=>1, 1=>1'::bigistore, 0);
 SELECT clamp_below('-5=>1, -1=>1, 0=>0, 1=>1'::bigistore, 0);
 SELECT clamp_below('-5=>1, -1=>1, 0=>1, 1=>1'::bigistore, 0);
 SELECT clamp_below('-5=>1, -1=>1, 0=>1, 1=>1'::bigistore, 2);
+SELECT clamp_below('1=>1, 2=>2147483647, 3=>42'::bigistore, 2);
 ROLLBACK;
 BEGIN;
 -- bigistore functions clamp should clamp keys that are above a specified threshold;


### PR DESCRIPTION
Fix for #98.